### PR TITLE
ENH: ES sink service map integration

### DIFF
--- a/situp-plugins/elasticsearch/README.md
+++ b/situp-plugins/elasticsearch/README.md
@@ -70,7 +70,7 @@ Default value is false. If set to true, user also needs to set `trace_analytics_
 ### Custom data type
 
 If both `trace_analytics_raw` and `trace_analytics_service_map` are set to false, the ES sink will ingest custom data type, i.e.
-user needs to provide custom [`index_alias`](#index_alias).
+user needs to provide custom [index_alias](#index_alias).
 
 ### <a name="index_alias"></a>Index alias
 

--- a/situp-plugins/elasticsearch/README.md
+++ b/situp-plugins/elasticsearch/README.md
@@ -12,8 +12,8 @@ pipeline:
   sink:
     elasticsearch:
       hosts: ["http://localhost:9200"]
-      index_type: raw
-      index_alias: "apm-span"
+      trace_analytics_raw: true
+      trace_analytics_service_map: false
       template_file: /your/local/template-file.json
       dlq_file: /your/local/dlq-file
       bulk_size: 4
@@ -23,11 +23,9 @@ pipeline:
 
 A list of IP addresses of elasticsearch nodes.
 
-### Index type (Optional)
+### Trace analytics raw
 
-A String takes value among `raw`, `service_map` and `custom`. Default to `raw`.
-
-- `raw`: represents APM raw span data. e.g.
+A boolean flag indicates APM trace analytics raw span data type. e.g.
 
 ```$xslt
 {
@@ -42,7 +40,11 @@ A String takes value among `raw`, `service_map` and `custom`. Default to `raw`.
 }
 ```
 
-- `service_map`: represents APM service map data. e.g.
+Default value is true.
+
+### Trace analytics service map
+
+A boolean flag indicates APM trace analytics service map data type. e.g.
 
 ```$xslt
 {
@@ -63,22 +65,27 @@ A String takes value among `raw`, `service_map` and `custom`. Default to `raw`.
 }
 ```
 
-- `custom`: custom data. User needs to provide `index_alias` explicitly.
+Default value is false. If set to true, user also needs to set `trace_analytics_raw` to false.
 
-### Index alias
+### Custom data type
 
-A String used as index alias if `index_type` is `raw` and otherwise used as index name. Default value depends on `index_type` value as follows:
+If both `trace_analytics_raw` and `trace_analytics_service_map` are set to false, the ES sink will ingest custom data type, i.e.
+user needs to provide custom [`index_alias`](#index_alias).
 
-- `raw`: otel-v1-apm-span-index
-- `service_map`: otel-v1-apm-service-map  
+### <a name="index_alias"></a>Index alias
+
+A String used as index alias if `trace_analytics_raw` is `true` and otherwise used just as index name. Default value depends on data type flags as follows:
+
+- `trace_analytics_raw`: otel-v1-apm-span-index
+- `trace_analytics_service_map`: otel-v1-apm-service-map  
 - `custom`: No default value. User needs to provide the index name
 
 `index_alias` is also reserved for index template name and `index_patterns` in the [index template](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html) created by the Elasticsearch sink. 
 
-- `raw`: 
+- `trace_analytics_raw`: 
    - `name`: `<index_alias>-index-template` 
    - `index_patterns`: `[<index_alias>-*]`
-- `service_map`: 
+- `trace_analytics_service_map`: 
    - `name`: `<index_alias>-index-template`
    - `index_patterns`: `[<index_alias>]`
 - `custom`: User needs to provide template file path. See [Template file](#template_file)
@@ -92,9 +99,9 @@ A json file path to be read as index template for APM data ingestion. The json f
 
 Default template file (no template file path given) depends on `index_type`:
 
-- `raw`: [otel-v1-apm-span-index-template.json](https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/blob/master/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json)
+- `trace_analytics_raw`: [otel-v1-apm-span-index-template.json](https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/blob/master/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json)
 
-- `service_map`: [otel-v1-apm-service-map-index-template.json](https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/blob/master/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-service-map-index-template.json)
+- `trace_analytics_service_map`: [otel-v1-apm-service-map-index-template.json](https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/blob/master/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-service-map-index-template.json)
 
 - `custom`: None (no index template will be created)
 

--- a/situp-plugins/elasticsearch/README.md
+++ b/situp-plugins/elasticsearch/README.md
@@ -90,135 +90,13 @@ A String used as index alias if `index_type` is `raw` and otherwise used as inde
 A json file path to be read as index template for APM data ingestion. The json file content should be the json value of
 `"template"` key in the json content of elasticsearch [Index templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html).
 
-Default template json (no template file path given) depends on `index_type`:
+Default template file (no template file path given) depends on `index_type`:
 
-- `raw`: 
+- `raw`: [otel-v1-apm-span-index-template.json](https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/blob/master/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json)
 
-```$xslt
-{
-  "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 2
-  },
-  "mappings": {
-    "date_detection": false,
-    "dynamic_templates": [
-      {
-        "strings_as_keyword": {
-          "mapping": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "match_mapping_type": "string"
-        }
-      }
-    ],
-    "_source": {
-      "enabled": true
-    },
-    "properties": {
-      "traceId": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      },
-      "spanId": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      },
-      "name": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      },
-      "kind": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      },
-      "startTime": {
-        "type": "date_nanos"
-      },
-      "endTime": {
-        "type": "date_nanos"
-      },
-      "resource.attributes.service.name": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      }
-    }
-  }
-}
-```
+- `service_map`: [otel-v1-apm-service-map-index-template.json](https://github.com/opendistro-for-elasticsearch/simple-ingest-transformation-utility-pipeline/blob/master/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-service-map-index-template.json)
 
-- `service_map`
-
-```$xslt
-{
-  "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 2
-  },
-  "mappings": {
-    "date_detection": false,
-    "dynamic_templates": [
-      {
-        "strings_as_keyword": {
-          "mapping": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "match_mapping_type": "string"
-        }
-      }
-    ],
-    "_source": {
-      "enabled": true
-    },
-    "properties": {
-      "hashId": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      },
-      "serviceName": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      },
-      "kind": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      },
-      "destination": {
-        "properties": {
-          "domain": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "resource": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
-      "target": {
-        "properties": {
-          "domain": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          },
-          "resource": {
-            "ignore_above": 1024,
-            "type": "keyword"
-          }
-        }
-      },
-      "traceGroupName": {
-        "ignore_above": 1024,
-        "type": "keyword"
-      }
-    }
-  }
-}
-```
-
-- `custom`: no index template will be created
+- `custom`: None (no index template will be created)
 
 ### DLQ file (Optional)
 

--- a/situp-plugins/elasticsearch/README.md
+++ b/situp-plugins/elasticsearch/README.md
@@ -12,6 +12,9 @@ pipeline:
   sink:
     elasticsearch:
       hosts: ["http://localhost:9200"]
+      index_type: raw
+      index_alias: "apm-span"
+      template_file: /your/local/template-file.json
       dlq_file: /your/local/dlq-file
       bulk_size: 4
 ``` 
@@ -19,6 +22,203 @@ pipeline:
 ### Hosts
 
 A list of IP addresses of elasticsearch nodes.
+
+### Index type (Optional)
+
+A String takes value among `raw`, `service_map` and `custom`. Default to `raw`.
+
+- `raw`: represents APM raw span data. e.g.
+
+```$xslt
+{
+  "traceId":"bQ/2NNEmtuwsGAOR5ntCNw==",
+  "spanId":"mnO/qUT5ye4=",
+  "name":"io.opentelemetry.auto.servlet-3.0",
+  "kind":"SERVER",
+  "status":{},
+  "startTime":"2020-08-20T05:40:46.041011600Z",
+  "endTime":"2020-08-20T05:40:46.089556800Z",
+  ...
+}
+```
+
+- `service_map`: represents APM service map data. e.g.
+
+```$xslt
+{
+  "hashId": "aQ/2NNEmtuwsGAOR5ntCNwk=",
+  "serviceName": "Payment",
+  "kind": "Client",
+  "target":
+  {
+    "domain": "Purchase",
+    "resource": "Buy"
+  },
+  "destination":
+  {
+    "domain": "Purchase",
+    "resource": "Buy"
+  },
+  "traceGroupName": "MakePayement.auto"
+}
+```
+
+- `custom`: custom data. User needs to provide `index_alias` explicitly.
+
+### Index alias
+
+A String used as index alias if `index_type` is `raw` and otherwise used as index name. Default value depends on `index_type` value as follows:
+
+- `raw`: otel-v1-apm-span-index
+- `service_map`: otel-v1-apm-service-map  
+- `custom`: No default value. User needs to provide the index name
+
+`index_alias` is also reserved for index template name and `index_patterns` in the [index template](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html) created by the Elasticsearch sink. 
+
+- `raw`: 
+   - `name`: `<index_alias>-index-template` 
+   - `index_patterns`: `[<index_alias>-*]`
+- `service_map`: 
+   - `name`: `<index_alias>-index-template`
+   - `index_patterns`: `[<index_alias>]`
+- `custom`: User needs to provide template file path. See [Template file](#template_file)
+   - `name`: `<index_alias>-index-template`
+   - `index_patterns`: `[<index_alias>]`
+
+### <a name="template_file"></a>Template file (Optional)
+
+A json file path to be read as index template for APM data ingestion. The json file content should be the json value of
+`"template"` key in the json content of elasticsearch [Index templates API](https://www.elastic.co/guide/en/elasticsearch/reference/7.8/index-templates.html).
+
+Default template json (no template file path given) depends on `index_type`:
+
+- `raw`: 
+
+```$xslt
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 2
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings_as_keyword": {
+          "mapping": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "match_mapping_type": "string"
+        }
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "traceId": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "spanId": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "name": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "kind": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "startTime": {
+        "type": "date_nanos"
+      },
+      "endTime": {
+        "type": "date_nanos"
+      },
+      "resource.attributes.service.name": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      }
+    }
+  }
+}
+```
+
+- `service_map`
+
+```$xslt
+{
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 2
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings_as_keyword": {
+          "mapping": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "match_mapping_type": "string"
+        }
+      }
+    ],
+    "_source": {
+      "enabled": true
+    },
+    "properties": {
+      "hashId": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "serviceName": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "kind": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "destination": {
+        "properties": {
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "resource": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "target": {
+        "properties": {
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "resource": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "traceGroupName": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      }
+    }
+  }
+}
+```
+
+- `custom`: no index template will be created
 
 ### DLQ file (Optional)
 

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSink.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSink.java
@@ -154,7 +154,11 @@ public class ElasticsearchSink implements Sink<Record<String>> {
   private void createIndexTemplate() throws IOException {
     final String indexAlias = esSinkConfig.getIndexConfiguration().getIndexAlias();
     final PutIndexTemplateRequest putIndexTemplateRequest = new PutIndexTemplateRequest(indexAlias + "-index-template");
-    putIndexTemplateRequest.patterns(Collections.singletonList(indexAlias + "-*"));
+    if (indexType.equals(IndexConstants.RAW)) {
+      putIndexTemplateRequest.patterns(Collections.singletonList(indexAlias + "-*"));
+    } else {
+      putIndexTemplateRequest.patterns(Collections.singletonList(indexAlias));
+    }
     final URL jsonURL = esSinkConfig.getIndexConfiguration().getTemplateURL();
     final String templateJson = readTemplateURL(jsonURL);
     putIndexTemplateRequest.source(templateJson, XContentType.JSON);

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkConfiguration.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkConfiguration.java
@@ -24,37 +24,15 @@ public class ElasticsearchSinkConfiguration {
     return retryConfiguration;
   }
 
-  public static class Builder {
-    private ConnectionConfiguration connectionConfiguration;
-    private IndexConfiguration indexConfiguration = new IndexConfiguration.Builder().build();
-    private RetryConfiguration retryConfiguration = new RetryConfiguration.Builder().build();
-
-    public Builder(final ConnectionConfiguration connectionConfiguration) {
-      checkNotNull(connectionConfiguration, "connectionConfiguration cannot be null");
-      this.connectionConfiguration = connectionConfiguration;
-    }
-
-    public Builder withIndexConfiguration(final IndexConfiguration indexConfiguration) {
-      checkNotNull(indexConfiguration, "indexConfiguration cannot be null");
-      this.indexConfiguration = indexConfiguration;
-      return this;
-    }
-
-    public Builder withRetryConfiguration(final RetryConfiguration retryConfiguration) {
-      checkNotNull(retryConfiguration, "retryConfiguration cannot be null");
-      this.retryConfiguration = retryConfiguration;
-      return this;
-    }
-
-    public ElasticsearchSinkConfiguration build() {
-      return new ElasticsearchSinkConfiguration(this);
-    }
-  }
-
-  private ElasticsearchSinkConfiguration(final Builder builder) {
-    this.connectionConfiguration = builder.connectionConfiguration;
-    this.indexConfiguration = builder.indexConfiguration;
-    this.retryConfiguration = builder.retryConfiguration;
+  private ElasticsearchSinkConfiguration(
+          final ConnectionConfiguration connectionConfiguration, final IndexConfiguration indexConfiguration,
+          final RetryConfiguration retryConfiguration) {
+    checkNotNull(connectionConfiguration, "connectionConfiguration cannot be null");
+    checkNotNull(indexConfiguration, "indexConfiguration cannot be null");
+    checkNotNull(retryConfiguration, "retryConfiguration cannot be null");
+    this.connectionConfiguration = connectionConfiguration;
+    this.indexConfiguration = indexConfiguration;
+    this.retryConfiguration = retryConfiguration;
   }
 
   public static ElasticsearchSinkConfiguration readESConfig(final PluginSetting pluginSetting) {
@@ -63,9 +41,6 @@ public class ElasticsearchSinkConfiguration {
     final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
     final RetryConfiguration retryConfiguration = RetryConfiguration.readRetryConfig(pluginSetting);
 
-    return new ElasticsearchSinkConfiguration.Builder(connectionConfiguration)
-            .withIndexConfiguration(indexConfiguration)
-            .withRetryConfiguration(retryConfiguration)
-            .build();
+    return new ElasticsearchSinkConfiguration(connectionConfiguration, indexConfiguration, retryConfiguration);
   }
 }

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
@@ -18,12 +18,13 @@ public class IndexConfiguration {
   public static final String INDEX_ALIAS = "index_alias";
   public static final String TEMPLATE_FILE = "template_file";
   public static final String BULK_SIZE = "bulk_size";
-  public static final String DEFAULT_INDEX_TYPE = IndexConstants.RAW;
+  public static final String DOCUMENT_ID_FIELD = "document_id_field";
   public static final long DEFAULT_BULK_SIZE = 5L;
 
   private final String indexType;
   private final String indexAlias;
   private final URL templateURL;
+  private final String documentIdField;
   private final long bulkSize;
 
   public String getIndexType() {
@@ -38,6 +39,10 @@ public class IndexConfiguration {
     return templateURL;
   }
 
+  public String getDocumentIdField() {
+    return documentIdField;
+  }
+
   public long getBulkSize() {
     return bulkSize;
   }
@@ -47,6 +52,7 @@ public class IndexConfiguration {
     private boolean isServiceMap = false;
     private String indexAlias;
     private String templateFile;
+    private String documentIdField;
     private long bulkSize = DEFAULT_BULK_SIZE;
 
     public Builder setIsRaw(final Boolean isRaw) {
@@ -71,6 +77,12 @@ public class IndexConfiguration {
     public Builder withTemplateFile(final String templateFile) {
       checkArgument(templateFile != null, "templateFile cannot be null.");
       this.templateFile = templateFile;
+      return this;
+    }
+
+    public Builder withDocumentIdField(final String documentIdField) {
+      checkNotNull(documentIdField, "documentId field cannot be null");
+      this.documentIdField = documentIdField;
       return this;
     }
 
@@ -125,6 +137,14 @@ public class IndexConfiguration {
     }
     this.indexAlias = indexAlias;
     this.bulkSize = builder.bulkSize;
+
+    String documentIdField = builder.documentIdField;
+    if (indexType.equals(IndexConstants.RAW)) {
+      documentIdField = "spanId";
+    } else if (indexType.equals(IndexConstants.SERVICE_MAP)) {
+      documentIdField = "hashId";
+    }
+    this.documentIdField = documentIdField;
   }
 
   public static IndexConfiguration readIndexConfig(final PluginSetting pluginSetting) {
@@ -141,6 +161,10 @@ public class IndexConfiguration {
     }
     final Long batchSize = pluginSetting.getLongOrDefault(BULK_SIZE, DEFAULT_BULK_SIZE);
     builder = builder.withBulkSize(batchSize);
+    final String documentId = pluginSetting.getStringOrDefault(DOCUMENT_ID_FIELD, null);
+    if (documentId != null) {
+      builder = builder.withDocumentIdField(documentId);
+    }
     return builder.build();
   }
 }

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
@@ -43,7 +43,7 @@ public class IndexConfiguration {
   }
 
   public static class Builder {
-    private boolean isRaw = true;
+    private boolean isRaw = false;
     private boolean isServiceMap = false;
     private String indexAlias;
     private String templateFile;
@@ -98,28 +98,28 @@ public class IndexConfiguration {
     this.indexType = indexType;
 
     URL templateURL = null;
-    if (builder.templateFile == null) {
-      if (indexType.equals(IndexConstants.RAW)) {
-        templateURL = getClass().getClassLoader()
-            .getResource(IndexConstants.RAW_DEFAULT_TEMPLATE_FILE);
-      } else if (indexType.equals(IndexConstants.SERVICE_MAP)) {
-        templateURL = getClass().getClassLoader()
-            .getResource(IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
-      }
+    if (indexType.equals(IndexConstants.RAW)) {
+      templateURL = getClass().getClassLoader()
+          .getResource(IndexConstants.RAW_DEFAULT_TEMPLATE_FILE);
+    } else if (indexType.equals(IndexConstants.SERVICE_MAP)) {
+      templateURL = getClass().getClassLoader()
+          .getResource(IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
     } else {
-      try {
-        templateURL = new File(builder.templateFile).toURI().toURL();
-      } catch (MalformedURLException e) {
-        throw new IllegalStateException("Invalid template file path");
+      if (builder.templateFile != null) {
+        try {
+          templateURL = new File(builder.templateFile).toURI().toURL();
+        } catch (MalformedURLException e) {
+          throw new IllegalStateException("Invalid template file path");
+        }
       }
     }
     this.templateURL = templateURL;
 
     String indexAlias = builder.indexAlias;
-    if (indexAlias == null) {
-      if (IndexConstants.TYPE_TO_DEFAULT_ALIAS.containsKey(indexType)) {
+    if (IndexConstants.TYPE_TO_DEFAULT_ALIAS.containsKey(indexType)) {
         indexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(indexType);
-      } else {
+    } else {
+      if (indexAlias == null) {
         throw new IllegalStateException("Missing required properties:indexAlias");
       }
     }
@@ -129,7 +129,7 @@ public class IndexConfiguration {
 
   public static IndexConfiguration readIndexConfig(final PluginSetting pluginSetting) {
     IndexConfiguration.Builder builder = new IndexConfiguration.Builder();
-    builder.setIsRaw(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_RAW_FLAG, true));
+    builder.setIsRaw(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_RAW_FLAG, false));
     builder.setIsServiceMap(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_SERVICE_MAP_FLAG, false));
     final String indexAlias = pluginSetting.getStringOrDefault(INDEX_ALIAS, null);
     if (indexAlias != null) {

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
@@ -15,7 +15,7 @@ public class IndexConfiguration {
    */
   public static final String TRACE_ANALYTICS_RAW_FLAG = "trace_analytics_raw";
   public static final String TRACE_ANALYTICS_SERVICE_MAP_FLAG = "trace_analytics_service_map";
-  public static final String INDEX_ALIAS = "index_alias";
+  public static final String INDEX_ALIAS = "index";
   public static final String TEMPLATE_FILE = "template_file";
   public static final String BULK_SIZE = "bulk_size";
   public static final String DOCUMENT_ID_FIELD = "document_id_field";

--- a/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-service-map-index-template.json
+++ b/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-service-map-index-template.json
@@ -20,11 +20,43 @@
       "enabled": true
     },
     "properties": {
-      "source": {
+      "hashId": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "serviceName": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
+      "kind": {
         "ignore_above": 1024,
         "type": "keyword"
       },
       "destination": {
+        "properties": {
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "resource": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "target": {
+        "properties": {
+          "domain": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "resource": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          }
+        }
+      },
+      "traceGroupName": {
         "ignore_above": 1024,
         "type": "keyword"
       }

--- a/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
+++ b/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkIT.java
@@ -192,11 +192,11 @@ public class ElasticsearchSinkIT extends ESRestTestCase {
 
   private PluginSetting generatePluginSetting(final boolean isRaw, final boolean isServiceMap, final String indexAlias, final String templateFilePath) {
     final Map<String, Object> metadata = new HashMap<>();
-    metadata.put("trace_analytics_raw", isRaw);
-    metadata.put("trace_analytics_service_map", isServiceMap);
-    metadata.put("hosts", HOSTS);
-    metadata.put("index_alias", indexAlias);
-    metadata.put("template_file", templateFilePath);
+    metadata.put(IndexConfiguration.TRACE_ANALYTICS_RAW_FLAG, isRaw);
+    metadata.put(IndexConfiguration.TRACE_ANALYTICS_SERVICE_MAP_FLAG, isServiceMap);
+    metadata.put(ConnectionConfiguration.HOSTS, HOSTS);
+    metadata.put(IndexConfiguration.INDEX_ALIAS, indexAlias);
+    metadata.put(IndexConfiguration.TEMPLATE_FILE, templateFilePath);
 
     return new PluginSetting("elasticsearch", metadata);
   }

--- a/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfigurationTests.java
+++ b/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfigurationTests.java
@@ -132,16 +132,16 @@ public class IndexConfigurationTests {
       metadata.put(IndexConfiguration.TRACE_ANALYTICS_SERVICE_MAP_FLAG, isServiceMap);
     }
     if (indexAlias != null) {
-      metadata.put("index_alias", indexAlias);
+      metadata.put(IndexConfiguration.INDEX_ALIAS, indexAlias);
     }
     if (templateFilePath != null) {
-      metadata.put("template_file", templateFilePath);
+      metadata.put(IndexConfiguration.TEMPLATE_FILE, templateFilePath);
     }
     if (bulkSize != null) {
-      metadata.put("bulk_size", bulkSize);
+      metadata.put(IndexConfiguration.BULK_SIZE, bulkSize);
     }
     if (documentIdField != null) {
-      metadata.put("document_id_field", documentIdField);
+      metadata.put(IndexConfiguration.DOCUMENT_ID_FIELD, documentIdField);
     }
 
     return new PluginSetting("elasticsearch", metadata);

--- a/situp-plugins/elasticsearch/src/test/resources/service-map-1.json
+++ b/situp-plugins/elasticsearch/src/test/resources/service-map-1.json
@@ -1,0 +1,16 @@
+{
+  "hashId": "aQ/2NNEmtuwsGAOR5ntCNwk=",
+  "serviceName": "Payment",
+  "kind": "Client",
+  "target":
+  {
+    "domain": "Purchase",
+    "resource": "Buy"
+  },
+  "destination":
+  {
+    "domain": "Purchase",
+    "resource": "Buy"
+  },
+  "traceGroupName": "MakePayement.auto"
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR

1. Update service map index template
2. Extracts `hashId` as docId in service map data
3. Fixed index patterns for service map
4. Update README about service map config and custom data config
5. Added test coverage on service map

Note:

Instead of supporting two flags `trace.analytics.raw` and `trace.analytics.servicemap`, I used `index_type` that has 3 values: `raw`, `service_map`, `custom` which I think is more compact and simplifies the logic. I can return to the double flags if it leads to a better UX.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
