### PR TITLE
Adding hash id for relationships

### DIFF
--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapRelationship.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapRelationship.java
@@ -1,9 +1,18 @@
 package com.amazon.situp.plugins.processor;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.Objects;
+import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 
 
 public class ServiceMapRelationship {
+
+    /**
+     * ThreadLocal object to generate hashes of relationships
+     */
+    private static ThreadLocal<MessageDigest> THREAD_LOCAL_MESSAGE_DIGEST = new ThreadLocal<>();
+
     /**
      * Service name for the relationship. This corresponds to the source of the relationship
      */
@@ -12,32 +21,38 @@ public class ServiceMapRelationship {
     /**
      * Span kind for the relationship. This corresponds to the source span from the relationship
      */
-    private String spanKind;
+    private String kind;
 
     /**
      * Destination for the relationship. Meant to be correlated to a "target" field on a separate relationship
      */
-    private String destination;
+    private Endpoint destination;
 
     /**
      * Target for the relationship. Relates a "destination" from another relationship to a service name.
      */
-    private String target;
+    private Endpoint target;
 
     /**
      * Trace group name for this relationship
      */
     private String traceGroupName;
 
+    /**
+     * Deterministic hash id for this relationship
+     */
+    private String hashId;
+
     public ServiceMapRelationship() {
     }
 
-    private ServiceMapRelationship(String serviceName, String spanKind, String destination, String target, String traceGroupName) {
+    private ServiceMapRelationship(String serviceName, String kind, Endpoint destination, Endpoint target, String traceGroupName) {
         this.serviceName = serviceName;
-        this.spanKind = spanKind;
+        this.kind = kind;
         this.destination = destination;
         this.target = target;
         this.traceGroupName = traceGroupName;
+        this.hashId = md5Hash();
     }
 
     /**
@@ -47,9 +62,10 @@ public class ServiceMapRelationship {
     public static ServiceMapRelationship newDestinationRelationship (
             final String serviceName,
             final String spanKind,
-            final String destination,
+            final String resource,
+            final String domain,
             final String traceGroupName) {
-        return new ServiceMapRelationship(serviceName, spanKind, destination, null, traceGroupName);
+        return new ServiceMapRelationship(serviceName, spanKind, new Endpoint(resource, domain), null, traceGroupName);
     }
 
     /**
@@ -59,9 +75,10 @@ public class ServiceMapRelationship {
     public static ServiceMapRelationship newTargetRelationship (
             final String serviceName,
             final String spanKind,
-            final String target,
+            final String resource,
+            final String domain,
             final String traceGroupName) {
-        return new ServiceMapRelationship(serviceName, spanKind, null, target, traceGroupName);
+        return new ServiceMapRelationship(serviceName, spanKind, null, new Endpoint(resource, domain), traceGroupName);
     }
 
     public String getServiceName() {
@@ -72,30 +89,30 @@ public class ServiceMapRelationship {
         this.serviceName = serviceName;
     }
 
-    public String getSpanKind() {
-        return spanKind;
+    public String getKind() {
+        return kind;
     }
 
-    public void setSpanKind(String spanKind) {
-        this.spanKind = spanKind;
+    public void setKind(String kind) {
+        this.kind = kind;
     }
 
-    public String getDestination() {
+    public Endpoint getDestination() {
         return destination;
     }
 
-    public void setDestination(String destination) {
+    public void setDestination(Endpoint destination) {
         if(destination != null && target != null) {
             throw new RuntimeException("Cannot set both target and destination.");
         }
         this.destination = destination;
     }
 
-    public String getTarget() {
+    public Endpoint getTarget() {
         return target;
     }
 
-    public void setTarget(String target) {
+    public void setTarget(Endpoint target) {
         if(target != null && destination != null) {
             throw new RuntimeException("Cannot set both target and destination.");
         }
@@ -110,13 +127,21 @@ public class ServiceMapRelationship {
         this.traceGroupName = traceGroupName;
     }
 
+    public String getHashId() {
+        return hashId;
+    }
+
+    public void setHashId(String hashId) {
+        this.hashId = hashId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ServiceMapRelationship that = (ServiceMapRelationship) o;
         return Objects.equals(serviceName, that.serviceName) &&
-                Objects.equals(spanKind, that.spanKind) &&
+                Objects.equals(kind, that.kind) &&
                 Objects.equals(destination, that.destination) &&
                 Objects.equals(target, that.target) &&
                 Objects.equals(traceGroupName, that.traceGroupName);
@@ -124,6 +149,73 @@ public class ServiceMapRelationship {
 
     @Override
     public int hashCode() {
-        return Objects.hash(serviceName, spanKind, destination, target, traceGroupName);
+        return Objects.hash(serviceName, kind, destination, target, traceGroupName);
+    }
+
+    private String unhashedString() {
+        String result = serviceName + "," + kind + "," + traceGroupName + ",";
+        if (target != null) {
+            result += target.resource + "," + target.domain;
+        }
+        result += ",";
+        if(destination != null) {
+            result += destination.resource + "," + destination.domain;
+        }
+        return result;
+    }
+
+    private String md5Hash() {
+        if(THREAD_LOCAL_MESSAGE_DIGEST.get() == null) {
+            try {
+                THREAD_LOCAL_MESSAGE_DIGEST.set(MessageDigest.getInstance("MD5"));
+            } catch (NoSuchAlgorithmException e) {
+                e.printStackTrace();
+            }
+        }
+        THREAD_LOCAL_MESSAGE_DIGEST.get().reset();
+        THREAD_LOCAL_MESSAGE_DIGEST.get().update(unhashedString().getBytes());
+        return Base64.encode(THREAD_LOCAL_MESSAGE_DIGEST.get().digest());
+    }
+
+    public static class Endpoint {
+        private String resource;
+        private String domain;
+
+        public Endpoint(){}
+
+        public Endpoint(final String resource, final String domain) {
+            this.resource = resource;
+            this.domain = domain;
+        }
+
+        public String getResource() {
+            return resource;
+        }
+
+        public void setResource(String resource) {
+            this.resource = resource;
+        }
+
+        public String getDomain() {
+            return domain;
+        }
+
+        public void setDomain(String domain) {
+            this.domain = domain;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Endpoint endpoint = (Endpoint) o;
+            return Objects.equals(resource, endpoint.resource) &&
+                    Objects.equals(domain, endpoint.domain);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(resource, domain);
+        }
     }
 }

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapRelationship.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapRelationship.java
@@ -8,6 +8,8 @@ import com.sun.org.apache.xerces.internal.impl.dv.util.Base64;
 
 public class ServiceMapRelationship {
 
+    private static final String MD5 = "MD5";
+
     /**
      * ThreadLocal object to generate hashes of relationships
      */
@@ -167,9 +169,9 @@ public class ServiceMapRelationship {
     private String md5Hash() {
         if(THREAD_LOCAL_MESSAGE_DIGEST.get() == null) {
             try {
-                THREAD_LOCAL_MESSAGE_DIGEST.set(MessageDigest.getInstance("MD5"));
+                THREAD_LOCAL_MESSAGE_DIGEST.set(MessageDigest.getInstance(MD5));
             } catch (NoSuchAlgorithmException e) {
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
         THREAD_LOCAL_MESSAGE_DIGEST.get().reset();

--- a/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -83,17 +83,17 @@ public class ServiceMapStatefulProcessorTest {
 
 
         //Expected relationships
-        final ServiceMapRelationship frontendAuth = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, Span.SpanKind.CLIENT.name(), AUTHENTICATION_SERVICE, traceGroup1);
-        final ServiceMapRelationship authPassword = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, Span.SpanKind.CLIENT.name(), AUTHENTICATION_SERVICE, traceGroup1);
-        final ServiceMapRelationship frontendCheckout = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, Span.SpanKind.CLIENT.name(), CHECKOUT_SERVICE, traceGroup2);
-        final ServiceMapRelationship checkoutCart = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, Span.SpanKind.CLIENT.name(), CART_SERVICE, traceGroup2);
-        final ServiceMapRelationship checkoutPayment = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, Span.SpanKind.CLIENT.name(), PAYMENT_SERVICE, traceGroup2);
+        final ServiceMapRelationship frontendAuth = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, Span.SpanKind.CLIENT.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
+        final ServiceMapRelationship authPassword = ServiceMapRelationship.newDestinationRelationship(AUTHENTICATION_SERVICE, Span.SpanKind.CLIENT.name(), PASSWORD_DATABASE, "update", traceGroup1);
+        final ServiceMapRelationship frontendCheckout = ServiceMapRelationship.newDestinationRelationship(FRONTEND_SERVICE, Span.SpanKind.CLIENT.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
+        final ServiceMapRelationship checkoutCart = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, Span.SpanKind.CLIENT.name(), CART_SERVICE, "get_items", traceGroup2);
+        final ServiceMapRelationship checkoutPayment = ServiceMapRelationship.newDestinationRelationship(CHECKOUT_SERVICE, Span.SpanKind.CLIENT.name(), PAYMENT_SERVICE, "charge", traceGroup2);
 
-        final ServiceMapRelationship checkoutTarget = ServiceMapRelationship.newTargetRelationship(CHECKOUT_SERVICE, Span.SpanKind.SERVER.name(), CHECKOUT_SERVICE, traceGroup2);
-        final ServiceMapRelationship authTarget = ServiceMapRelationship.newTargetRelationship(AUTHENTICATION_SERVICE, Span.SpanKind.SERVER.name(), AUTHENTICATION_SERVICE, traceGroup1);
-        final ServiceMapRelationship passwordTarget = ServiceMapRelationship.newTargetRelationship(PASSWORD_DATABASE, Span.SpanKind.SERVER.name(), PASSWORD_DATABASE, traceGroup1);
-        final ServiceMapRelationship paymentTarget = ServiceMapRelationship.newTargetRelationship(PAYMENT_SERVICE, Span.SpanKind.SERVER.name(), PAYMENT_SERVICE, traceGroup2);
-        final ServiceMapRelationship cartTarget = ServiceMapRelationship.newTargetRelationship(CART_SERVICE, Span.SpanKind.SERVER.name(), CART_SERVICE, traceGroup2);
+        final ServiceMapRelationship checkoutTarget = ServiceMapRelationship.newTargetRelationship(CHECKOUT_SERVICE, Span.SpanKind.SERVER.name(), CHECKOUT_SERVICE, "checkout", traceGroup2);
+        final ServiceMapRelationship authTarget = ServiceMapRelationship.newTargetRelationship(AUTHENTICATION_SERVICE, Span.SpanKind.SERVER.name(), AUTHENTICATION_SERVICE, "reset", traceGroup1);
+        final ServiceMapRelationship passwordTarget = ServiceMapRelationship.newTargetRelationship(PASSWORD_DATABASE, Span.SpanKind.SERVER.name(), PASSWORD_DATABASE, "update", traceGroup1);
+        final ServiceMapRelationship paymentTarget = ServiceMapRelationship.newTargetRelationship(PAYMENT_SERVICE, Span.SpanKind.SERVER.name(), PAYMENT_SERVICE, "charge", traceGroup2);
+        final ServiceMapRelationship cartTarget = ServiceMapRelationship.newTargetRelationship(CART_SERVICE, Span.SpanKind.SERVER.name(), CART_SERVICE, "get_items", traceGroup2);
 
         final Set<ServiceMapRelationship> relationshipsFound = new HashSet<>();
 
@@ -151,7 +151,6 @@ public class ServiceMapStatefulProcessorTest {
         );
 
         Assert.assertTrue(evaluateEdges(relationshipsFound).containsAll(expectedSourceDests));
-
 
         //Make sure that future relationships that are equivalent are caught by cache
         final byte[] rootSpanId3 = ServiceMapTestUtils.getRandomBytes(8);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updating target and destination of ServiceMapRelationship to be Endpoint objects (with a resource and domain)
- Updating cache to check against actual object to avoid collisions with Integer hash code
- Adding hashId field to ServiceMapRelationship, which is an Md5 hash of all of the values for the object

Decided to use Md5 hash for document id because the 4 bytes for the integer hash code could lead to potential collisions when we get into the hundreds:

https://preshing.com/20110504/hash-collision-probabilities/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
