### PR TITLE
Add OTel Trace Source

### DIFF
--- a/situp-plugins/apmtracesource/README.md
+++ b/situp-plugins/apmtracesource/README.md
@@ -1,0 +1,16 @@
+# OTel Trace Source 
+
+This is a source which follows the [OTLP Protocol](https://github.com/open-telemetry/oteps/blob/master/text/0035-opentelemetry-protocol.md). This source supports ```OTLP/grpc``` and ```OTLP/HTTP```. Support for ```OTLP/HTTP+JSON``` is not complete due as the traceId and spanId will be ```base64``` and not ```HexString```.
+
+```
+source:
+    otel_trace_source:
+```
+
+## Configurations
+
+* port => Default is ```21890```. 
+* request_timeout => Default is ```10_000``` millis.
+* ssl => Default is ```false```.
+* sslKeyCertChainFile => Should be provided if ```ssl``` is set to ```true```
+* sslKeyFile => Should be provided if ```ssl``` is set to ```true```

--- a/situp-plugins/apmtracesource/build.gradle
+++ b/situp-plugins/apmtracesource/build.gradle
@@ -6,9 +6,10 @@ plugins {
 dependencies {
     compile project(':situp-api')
     compile project(':situp-plugins:common')
-    implementation 'io.netty:netty-all:4.1.51.Final'
     implementation 'io.opentelemetry:opentelemetry-proto:0.6.0'
-    implementation 'com.google.protobuf:protobuf-java-util:3.11.0'
+    implementation 'com.google.protobuf:protobuf-java-util:3.13.0'
+    implementation "com.linecorp.armeria:armeria:1.0.0"
+    implementation "com.linecorp.armeria:armeria-grpc:1.0.0"
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
     testImplementation 'org.assertj:assertj-core:3.6.2'

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceGrpcService.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceGrpcService.java
@@ -1,0 +1,35 @@
+package com.amazon.situp.plugins.source.oteltracesource;
+
+import com.amazon.situp.model.buffer.Buffer;
+import com.amazon.situp.model.record.Record;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceResponse;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+
+import java.util.concurrent.TimeoutException;
+
+
+public class OTelTraceGrpcService extends TraceServiceGrpc.TraceServiceImplBase {
+    private final int bufferWriteTimeoutInMillis;
+    private final Buffer<Record<ExportTraceServiceRequest>> buffer;
+
+    public OTelTraceGrpcService(int bufferWriteTimeoutInMillis, final Buffer<Record<ExportTraceServiceRequest>> buffer) {
+        this.bufferWriteTimeoutInMillis = bufferWriteTimeoutInMillis;
+        this.buffer = buffer;
+    }
+
+    @Override
+    public void export(ExportTraceServiceRequest request, StreamObserver<ExportTraceServiceResponse> responseObserver) {
+        try {
+            buffer.write(new Record<>(request), bufferWriteTimeoutInMillis);
+            responseObserver.onNext(ExportTraceServiceResponse.newBuilder().build());
+            responseObserver.onCompleted();
+        } catch (TimeoutException e) {
+            responseObserver
+                    .onError(Status.RESOURCE_EXHAUSTED.withDescription("Buffer is full, request timed out.")
+                            .asException());
+        }
+    }
+}

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
@@ -1,0 +1,81 @@
+package com.amazon.situp.plugins.source.oteltracesource;
+
+import com.amazon.situp.model.PluginType;
+import com.amazon.situp.model.annotations.SitupPlugin;
+import com.amazon.situp.model.buffer.Buffer;
+import com.amazon.situp.model.configuration.PluginSetting;
+import com.amazon.situp.model.record.Record;
+import com.amazon.situp.model.source.Source;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.grpc.GrpcService;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.util.concurrent.ExecutionException;
+
+@SitupPlugin(name = "otel_trace_source", type = PluginType.SOURCE)
+public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>> {
+    private static final Logger LOG = LoggerFactory.getLogger(OTelTraceSource.class);
+    private final OTelTraceSourceConfig oTelTraceSourceConfig;
+    private Server server;
+
+    public OTelTraceSource(final PluginSetting pluginSetting) {
+        oTelTraceSourceConfig = OTelTraceSourceConfig.buildConfig(pluginSetting);
+    }
+
+    @Override
+    public void start(Buffer<Record<ExportTraceServiceRequest>> buffer) {
+        if (server == null) {
+            final ServerBuilder sb = Server.builder();
+            sb.service(
+                    GrpcService
+                            .builder()
+                            .addService(new OTelTraceGrpcService(oTelTraceSourceConfig.getRequestTimeoutInMillis(), buffer))
+                            .enableUnframedRequests(true) // This will enable non-Grpc requests
+                            .useClientTimeoutHeader(false)
+                            .build());
+            sb.requestTimeoutMillis(oTelTraceSourceConfig.getRequestTimeoutInMillis());
+            if (oTelTraceSourceConfig.isSsl()) {
+                sb.https(oTelTraceSourceConfig.getPort()).tls(new File(oTelTraceSourceConfig.getSslKeyCertChainFile()),
+                        new File(oTelTraceSourceConfig.getSslKeyFile()));
+            } else {
+                sb.http(oTelTraceSourceConfig.getPort());
+            }
+            //TODO: Expose BlockingTaskExecutor/Connections
+            server = sb.build();
+        }
+        try {
+            server.start().get();
+            LOG.info("Started otel_trace_source...");
+        } catch (ExecutionException ex) {
+            LOG.error("otel_trace_source failed to start due to:", ex.getCause());
+        } catch (InterruptedException ex) {
+            LOG.error("otel_trace_source start got interrupted:", ex);
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (server != null) {
+            try {
+                server.stop().get();
+                LOG.info("Stopped otel_trace_source.");
+            } catch (ExecutionException ex) {
+                LOG.error("otel_trace_source failed to stop due to:", ex.getCause());
+            } catch (InterruptedException ex) {
+                LOG.error("otel_trace_source stop got interrupted:", ex);
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+
+    public OTelTraceSourceConfig getoTelTraceSourceConfig() {
+        return oTelTraceSourceConfig;
+    }
+}

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSourceConfig.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSourceConfig.java
@@ -1,0 +1,62 @@
+package com.amazon.situp.plugins.source.oteltracesource;
+
+import com.amazon.situp.model.configuration.PluginSetting;
+
+public class OTelTraceSourceConfig {
+    private static final String REQUEST_TIMEOUT = "request_timeout";
+    private static final String PORT = "port";
+    private static final String SSL = "ssl";
+    private static final String SSL_KEY_CERT_FILE = "sslKeyCertChainFile";
+    private static final String SSL_KEY_FILE = "sslKeyFile";
+    private static final int DEFAULT_REQUEST_TIMEOUT = 10_000;
+    private static final int DEFAULT_PORT = 21890;
+    private static final boolean DEFAULT_SSL = false;
+    private final int requestTimeoutInMillis;
+    private final int port;
+    private final boolean ssl;
+    private final String sslKeyCertChainFile;
+    private final String sslKeyFile;
+
+
+    private OTelTraceSourceConfig(int requestTimeoutInMillis, int port, boolean isSSL, String sslKeyCertChainFile, String sslKeyFile) {
+        this.requestTimeoutInMillis = requestTimeoutInMillis;
+        this.port = port;
+        this.ssl = isSSL;
+        this.sslKeyCertChainFile = sslKeyCertChainFile;
+        this.sslKeyFile = sslKeyFile;
+        if (ssl && (sslKeyCertChainFile == null || sslKeyCertChainFile.isEmpty())) {
+            throw new IllegalArgumentException(String.format("%s is enable, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
+        }
+        if (ssl && (sslKeyFile == null || sslKeyFile.isEmpty())) {
+            throw new IllegalArgumentException(String.format("%s is enable, %s can not be empty or null", SSL, SSL_KEY_CERT_FILE));
+        }
+    }
+
+    public static OTelTraceSourceConfig buildConfig(final PluginSetting pluginSetting) {
+        return new OTelTraceSourceConfig(pluginSetting.getIntegerOrDefault(REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT),
+                pluginSetting.getIntegerOrDefault(PORT, DEFAULT_PORT),
+                pluginSetting.getBooleanOrDefault(SSL, DEFAULT_SSL),
+                pluginSetting.getStringOrDefault(SSL_KEY_CERT_FILE, null),
+                pluginSetting.getStringOrDefault(SSL_KEY_FILE, null));
+    }
+
+    public int getRequestTimeoutInMillis() {
+        return requestTimeoutInMillis;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean isSsl() {
+        return ssl;
+    }
+
+    public String getSslKeyCertChainFile() {
+        return sslKeyCertChainFile;
+    }
+
+    public String getSslKeyFile() {
+        return sslKeyFile;
+    }
+}

--- a/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/source/oteltrace/OTelTraceSourceTest.java
+++ b/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/source/oteltrace/OTelTraceSourceTest.java
@@ -1,0 +1,103 @@
+package com.amazon.situp.plugins.source.oteltrace;
+
+import com.amazon.situp.model.configuration.PluginSetting;
+import com.amazon.situp.model.record.Record;
+import com.amazon.situp.plugins.buffer.BlockingBuffer;
+import com.amazon.situp.plugins.source.oteltracesource.OTelTraceSource;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.*;
+import io.grpc.StatusRuntimeException;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.collector.trace.v1.TraceServiceGrpc;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+public class OTelTraceSourceTest {
+
+    private OTelTraceSource SOURCE;
+
+    private String getUri() {
+        return "gproto+http://127.0.0.1:" + SOURCE.getoTelTraceSourceConfig().getPort() + '/';
+    }
+
+    @BeforeEach
+    private void beforeEach() {
+        final HashMap<String, Object> integerHashMap = new HashMap<>();
+        integerHashMap.put("request_timeout", 1);
+        SOURCE = new OTelTraceSource(new PluginSetting("otel_trace_source", integerHashMap));
+        SOURCE.start(getBuffer());
+    }
+
+    @AfterEach
+    private void afterEach() {
+        SOURCE.stop();
+    }
+
+    private BlockingBuffer<Record<ExportTraceServiceRequest>> getBuffer() {
+        final HashMap<String, Object> integerHashMap = new HashMap<>();
+        integerHashMap.put("buffer_size", 1);
+        return new BlockingBuffer<>(new PluginSetting("blocking_buffer", integerHashMap));
+    }
+
+
+    void addOneRequest() {
+        final TraceServiceGrpc.TraceServiceBlockingStub client = Clients.newClient(getUri(), TraceServiceGrpc.TraceServiceBlockingStub.class);
+        client.export(ExportTraceServiceRequest.newBuilder().build());
+    }
+
+    @Test
+    void testSuccess(){
+        addOneRequest();
+    }
+
+    @Test
+    void testBufferFull() {
+        addOneRequest();
+        final TraceServiceGrpc.TraceServiceBlockingStub client = Clients.newClient(getUri(), TraceServiceGrpc.TraceServiceBlockingStub.class);
+        try {
+            client.export(ExportTraceServiceRequest.newBuilder().build());
+            fail("Buffer should be full");
+        } catch (RuntimeException ex) {
+            assertThat(ex instanceof StatusRuntimeException).isTrue();
+        }
+    }
+
+    @Test
+    void testHttpFullJson() throws InvalidProtocolBufferException, ExecutionException, InterruptedException {
+        addOneRequest();
+        final AggregatedHttpResponse res2 = WebClient.of().execute(RequestHeaders.builder()
+                        .scheme(SessionProtocol.HTTP)
+                        .authority("0.0.0.0:21890")
+                        .method(HttpMethod.POST)
+                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                        .contentType(MediaType.JSON_UTF_8)
+                        .build(),
+                HttpData.copyOf(JsonFormat.printer().print(ExportTraceServiceRequest.newBuilder().build()).getBytes())).aggregate().get();
+        assertThat(res2.status().equals(HttpStatus.TOO_MANY_REQUESTS)).isTrue();
+    }
+
+    @Test
+    void testHttpFullBytes() throws InvalidProtocolBufferException, ExecutionException, InterruptedException {
+        addOneRequest();
+        final AggregatedHttpResponse res2 = WebClient.of().execute(RequestHeaders.builder()
+                        .scheme(SessionProtocol.HTTP)
+                        .authority("0.0.0.0:21890")
+                        .method(HttpMethod.POST)
+                        .path("/opentelemetry.proto.collector.trace.v1.TraceService/Export")
+                        .contentType(MediaType.PROTOBUF)
+                        .build(),
+                HttpData.copyOf(ExportTraceServiceRequest.newBuilder().build().toByteArray())).aggregate().get();
+        assertThat(res2.status().equals(HttpStatus.TOO_MANY_REQUESTS)).isTrue();
+    }
+}


### PR DESCRIPTION
*Issue #55 *

*Description of changes:*
* Create a new Source plugin called ```otel_trace_source```
* This source is based of the new framework called [Armeria](https://github.com/line/armeria). This uses the OTLP protocol and supports OTLP/gRPC, OTLP/HTTP (protobuf) and OTLP/HTTP+JSON (partially).




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
