### PR TITLE
Update plugins build to include all plugins as dependencies

### DIFF
--- a/situp-core/build.gradle
+++ b/situp-core/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     compile project(':situp-api')
-    compile project(':situp-plugins:common')
+    compile project(':situp-plugins')
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${versionMap.jackson_dataformat_yaml}"
     implementation "javax.validation:validation-api:${versionMap.validation_api}"

--- a/situp-plugins/build.gradle
+++ b/situp-plugins/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+    subprojects.forEach { compile project(':situp-plugins:' + it.name) }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Updated the core build to include the `situp-plugins` root project
* Updated the `situp-plugins` build to include all sub-project plugins as dependencies

### Testing:
* The sub-project under `situp-plugins` namely elasticsearch has failing tests which is failing the build - Below is the 

```
> Task :situp-plugins:apmtracesource:compileJava
Note: /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/processor/oteltrace/OTelTraceRawProcessor.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :situp-plugins:service-map-stateful:compileJava
Note: /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :situp-plugins:elasticsearch:integTestRunner

REPRODUCE WITH: ./gradlew ':situp-plugins:elasticsearch:integTestRunner' --tests "com.amazon.situp.plugins.sink.elasticsearch.ElasticsearchSinkIT.testOutputCustomIndex" -Dtests.seed=B26D675B53A416A0 -Dtests.security.manager=false -Dtests.locale=uk -Dtests.timezone=Pacific/Midway -Druntime.java=14

com.amazon.situp.plugins.sink.elasticsearch.ElasticsearchSinkIT > testOutputCustomIndex FAILED
    java.lang.AssertionError: expected:<1> but was:<0>
        at __randomizedtesting.SeedInfo.seed([B26D675B53A416A0:6869AC15926E29D7]:0)
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:647)
        at org.junit.Assert.assertEquals(Assert.java:633)
        at com.amazon.situp.plugins.sink.elasticsearch.ElasticsearchSinkIT.testOutputCustomIndex(ElasticsearchSinkIT.java:188)

REPRODUCE WITH: ./gradlew ':situp-plugins:elasticsearch:integTestRunner' --tests "com.amazon.situp.plugins.sink.elasticsearch.ElasticsearchSinkIT.testOutputCustomIndex" -Dtests.seed=B26D675B53A416A0 -Dtests.security.manager=false -Dtests.locale=uk -Dtests.timezone=Pacific/Midway -Druntime.java=14

com.amazon.situp.plugins.sink.elasticsearch.ElasticsearchSinkIT > classMethod FAILED
    com.carrotsearch.randomizedtesting.ThreadLeakError: 5 threads leaked from SUITE scope at com.amazon.situp.plugins.sink.elasticsearch.ElasticsearchSinkIT: 
       1) Thread[id=61, name=I/O dispatcher 32, state=RUNNABLE, group=TGRP-ElasticsearchSinkIT]
            at java.base@14.0.2/sun.nio.ch.KQueue.poll(Native Method)
            at java.base@14.0.2/sun.nio.ch.KQueueSelectorImpl.doSelect(KQueueSelectorImpl.java:122)
            at java.base@14.0.2/sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:129)
```

Disabled the tests and ran the build which succeeded - 

```
f45c89b92765:simple-ingest-transformation-utility-pipeline byadav$ ./gradlew build
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.5
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-14.0.2.jdk/Contents/Home
  Random Testing Seed   : 8EF6431C13840BEB
  In FIPS 140 mode      : false
=======================================

> Task :situp-plugins:elasticsearch:checkstyleTest
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/BackOffUtilsTests.java:1: Missing package declaration. [PackageDeclaration]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/BulkRetryStrategyTests.java:1: Missing package declaration. [PackageDeclaration]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ConnectionConfigurationTests.java:1: Missing package declaration. [PackageDeclaration]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ConnectionPipelineComponentIT.java:1: Missing package declaration. [PackageDeclaration]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkIT.java:1: Missing package declaration. [PackageDeclaration]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkIT.java:193: Line is longer than 140 characters (found 154). [LineLength]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkIT.java:226: Line is longer than 140 characters (found 174). [LineLength]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/ElasticsearchSinkIT.java:256: Line is longer than 140 characters (found 142). [LineLength]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfigurationTests.java:1: Missing package declaration. [PackageDeclaration]
[ant:checkstyle] [ERROR] /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/RetryConfigurationTests.java:1: Missing package declaration. [PackageDeclaration]
Checkstyle rule violations were found. See the report at: file:///workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/elasticsearch/build/reports/checkstyle/test.xml
Checkstyle files with violations: 7
Checkstyle violations by severity: [error:10]


> Task :situp-plugins:service-map-stateful:test
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.lmdbjava.ByteBufferProxy$AbstractByteBufferProxy (file:/Users/byadav/.gradle/caches/modules-2/files-2.1/org.lmdbjava/lmdbjava/0.8.1/6980f7c4a21246bdccdd10b6dcfd647d49f9761c/lmdbjava-0.8.1.jar) to field java.nio.Buffer.address
WARNING: Please consider reporting this to the maintainers of org.lmdbjava.ByteBufferProxy$AbstractByteBufferProxy
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 22s

```

Raising the PR without disabling the tests to let the owner of the plugin to update the tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
