### PR TITLE
Support multiple sinks and multiple processors

### DIFF
--- a/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
+++ b/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
@@ -57,7 +57,7 @@ public class PipelineConfiguration {
 
     private List<PluginSetting> getSinksFromConfiguration(
             final List<Map.Entry<String, Map<String, Object>>> sinkConfigurations) {
-        if (sinkConfigurations==null || sinkConfigurations.isEmpty()) {
+        if (sinkConfigurations == null || sinkConfigurations.isEmpty()) {
             throw new IllegalArgumentException("Invalid configuration, at least one sink is required");
         }
         return sinkConfigurations.stream().map(PipelineConfiguration::getPluginSettingFromConfiguration).collect(Collectors.toList());
@@ -65,7 +65,7 @@ public class PipelineConfiguration {
 
     private List<PluginSetting> getProcessorsFromConfiguration(
             final List<Map.Entry<String, Map<String, Object>>> processorConfigurations) {
-        if (processorConfigurations==null || processorConfigurations.isEmpty()) {
+        if (processorConfigurations == null || processorConfigurations.isEmpty()) {
             return Collections.emptyList();
         }
         return processorConfigurations.stream().map(PipelineConfiguration::getPluginSettingFromConfiguration).collect(Collectors.toList());
@@ -74,8 +74,8 @@ public class PipelineConfiguration {
 
 
     private static PluginSetting getPluginSettingFromConfiguration(
-            final Map.Entry<String, Map<String, Object>> processorConfiguration) {
-        return new PluginSetting(processorConfiguration.getKey(), processorConfiguration.getValue());
+            final Map.Entry<String, Map<String, Object>> configuration) {
+        return new PluginSetting(configuration.getKey(), configuration.getValue());
     }
 
     private Integer getWorkersFromConfiguration(final Integer workersConfiguration) {

--- a/situp-core/src/test/java/com/amazon/situp/TestDataProvider.java
+++ b/situp-core/src/test/java/com/amazon/situp/TestDataProvider.java
@@ -20,6 +20,9 @@ public class TestDataProvider {
     public static final String INCORRECT_SOURCE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/incorrect_source_multiple_pipeline_configuration.yml";
     public static final String MISSING_NAME_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/missing_name_multiple_pipeline_configuration.yml";
     public static final String MISSING_PIPELINE_MULTIPLE_PIPELINE_CONFIG_FILE = "src/test/resources/missing_pipeline_multiple_pipeline_configuration.yml";
+    public static final String VALID_MULTIPLE_SINKS_CONFIG_FILE = "src/test/resources/valid_multiple_sinks.yml";
+    public static final String VALID_MULTIPLE_PROCESSORS_CONFIG_FILE = "src/test/resources/valid_multiple_sinks.yml";
+
     public static Set<String> VALID_MULTIPLE_PIPELINE_NAMES = new HashSet<>(Arrays.asList("test-pipeline-1",
             "test-pipeline-2", "test-pipeline-3"));
     public static PluginSetting VALID_PLUGIN_SETTING_1 = new PluginSetting(TEST_PLUGIN_NAME_1, validSettingsForPlugin());

--- a/situp-core/src/test/java/com/amazon/situp/TestDataProvider.java
+++ b/situp-core/src/test/java/com/amazon/situp/TestDataProvider.java
@@ -3,8 +3,10 @@ package com.amazon.situp;
 import com.amazon.situp.model.configuration.PluginSetting;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,17 +31,16 @@ public class TestDataProvider {
         return settingsMap;
     }
 
-    public static Map<String, Map<String, Object>> validSingleConfiguration() {
-        final Map<String, Map<String, Object>> singleConfiguration = new HashMap<>();
-        singleConfiguration.put(TEST_PLUGIN_NAME_1, validSettingsForPlugin());
-        return singleConfiguration;
+    public static Map.Entry<String, Map<String, Object>> validSingleConfiguration() {
+        return Map.entry(TEST_PLUGIN_NAME_1, validSettingsForPlugin());
     }
 
-    public static Map<String, Map<String, Object>> validMultipleConfiguration() {
-        final Map<String, Map<String, Object>> multipleConfiguration = new HashMap<>();
-        multipleConfiguration.put(TEST_PLUGIN_NAME_1, validSettingsForPlugin());
-        multipleConfiguration.put(TEST_PLUGIN_NAME_2, validSettingsForPlugin());
-        return multipleConfiguration;
+    public static List<Map.Entry<String, Map<String, Object>>> validMultipleConfiguration() {
+        return Arrays.asList(Map.entry(TEST_PLUGIN_NAME_1, validSettingsForPlugin()),Map.entry(TEST_PLUGIN_NAME_2, validSettingsForPlugin()));
+    }
+
+    public static List<Map.Entry<String, Map<String, Object>>> validMultipleConfigurationOfSizeOne() {
+        return Collections.singletonList(Map.entry(TEST_PLUGIN_NAME_1, validSettingsForPlugin()));
     }
 
 }

--- a/situp-core/src/test/java/com/amazon/situp/parser/PipelineParserTests.java
+++ b/situp-core/src/test/java/com/amazon/situp/parser/PipelineParserTests.java
@@ -11,6 +11,8 @@ import static com.amazon.situp.TestDataProvider.MISSING_NAME_MULTIPLE_PIPELINE_C
 import static com.amazon.situp.TestDataProvider.MISSING_PIPELINE_MULTIPLE_PIPELINE_CONFIG_FILE;
 import static com.amazon.situp.TestDataProvider.VALID_MULTIPLE_PIPELINE_CONFIG_FILE;
 import static com.amazon.situp.TestDataProvider.VALID_MULTIPLE_PIPELINE_NAMES;
+import static com.amazon.situp.TestDataProvider.VALID_MULTIPLE_PROCESSORS_CONFIG_FILE;
+import static com.amazon.situp.TestDataProvider.VALID_MULTIPLE_SINKS_CONFIG_FILE;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -62,5 +64,17 @@ public class PipelineParserTests {
         } catch (RuntimeException ex) {
             assertThat(ex.getMessage(), is("Invalid configuration, no pipeline is defined with name test-pipeline-4"));
         }
+    }
+
+    @Test
+    public void testMultipleSinks() {
+        final PipelineParser pipelineParser = new PipelineParser(VALID_MULTIPLE_SINKS_CONFIG_FILE);
+        pipelineParser.parseConfiguration();
+    }
+
+    @Test
+    public void testMultipleProcessors() {
+        final PipelineParser pipelineParser = new PipelineParser(VALID_MULTIPLE_PROCESSORS_CONFIG_FILE);
+        pipelineParser.parseConfiguration();
     }
 }

--- a/situp-core/src/test/java/com/amazon/situp/parser/model/PipelineConfigurationTests.java
+++ b/situp-core/src/test/java/com/amazon/situp/parser/model/PipelineConfigurationTests.java
@@ -12,6 +12,7 @@ import static com.amazon.situp.TestDataProvider.TEST_WORKERS;
 import static com.amazon.situp.TestDataProvider.VALID_PLUGIN_SETTING_1;
 import static com.amazon.situp.TestDataProvider.VALID_PLUGIN_SETTING_2;
 import static com.amazon.situp.TestDataProvider.validMultipleConfiguration;
+import static com.amazon.situp.TestDataProvider.validMultipleConfigurationOfSizeOne;
 import static com.amazon.situp.TestDataProvider.validSingleConfiguration;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -23,7 +24,7 @@ public class PipelineConfigurationTests {
     public void testPipelineConfigurationCreation() {
         final PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(validSingleConfiguration(),
                 null,
-                validSingleConfiguration(),
+                validMultipleConfigurationOfSizeOne(),
                 validMultipleConfiguration(),
                 TEST_WORKERS, TEST_DELAY);
         final PluginSetting actualSourcePluginSetting = pipelineConfiguration.getSourcePluginSetting();
@@ -46,7 +47,7 @@ public class PipelineConfigurationTests {
         final PipelineConfiguration pipelineConfiguration = new PipelineConfiguration(validSingleConfiguration(),
                 null,
                 null,
-                validSingleConfiguration(),
+                validMultipleConfigurationOfSizeOne(),
                 null, null);
         final PluginSetting actualSourcePluginSetting = pipelineConfiguration.getSourcePluginSetting();
         final List<PluginSetting> actualProcessorPluginSettings = pipelineConfiguration.getProcessorPluginSettings();
@@ -63,43 +64,13 @@ public class PipelineConfigurationTests {
     }
 
     @Test() //not using expected to assert the message
-    public void testMultipleSourceConfiguration() {
-        try {
-            new PipelineConfiguration(
-                    validMultipleConfiguration(),
-                    validSingleConfiguration(),
-                    validSingleConfiguration(),
-                    validSingleConfiguration(),
-                    TEST_WORKERS, TEST_DELAY);
-        } catch (IllegalArgumentException ex) {
-            assertThat(ex.getMessage(), is("Incorrect configuration for component source, " +
-                    "maximum allowed plugins are 1"));
-        }
-    }
-
-    @Test() //not using expected to assert the message
-    public void testMultipleBufferConfiguration() {
-        try {
-            new PipelineConfiguration(
-                    validSingleConfiguration(),
-                    validMultipleConfiguration(),
-                    validSingleConfiguration(),
-                    validSingleConfiguration(),
-                    TEST_WORKERS, TEST_DELAY);
-        } catch (IllegalArgumentException ex) {
-            assertThat(ex.getMessage(), is("Incorrect configuration for component buffer, " +
-                    "maximum allowed plugins are 1"));
-        }
-    }
-
-    @Test() //not using expected to assert the message
     public void testNoSourceConfiguration() {
         try {
             new PipelineConfiguration(
                     null,
+                    validSingleConfiguration(),
                     validMultipleConfiguration(),
-                    validSingleConfiguration(),
-                    validSingleConfiguration(),
+                    validMultipleConfiguration(),
                     TEST_WORKERS, TEST_DELAY);
         } catch (IllegalArgumentException ex) {
             assertThat(ex.getMessage(), is("Invalid configuration, source is a required component"));
@@ -112,7 +83,7 @@ public class PipelineConfigurationTests {
             new PipelineConfiguration(
                     validSingleConfiguration(),
                     validSingleConfiguration(),
-                    validSingleConfiguration(),
+                    validMultipleConfiguration(),
                     null,
                     TEST_WORKERS, TEST_DELAY);
         } catch (IllegalArgumentException ex) {
@@ -126,8 +97,8 @@ public class PipelineConfigurationTests {
             new PipelineConfiguration(
                     validSingleConfiguration(),
                     validSingleConfiguration(),
-                    validSingleConfiguration(),
-                    validSingleConfiguration(),
+                    validMultipleConfiguration(),
+                    validMultipleConfiguration(),
                     0, TEST_DELAY);
         } catch (IllegalArgumentException ex) {
             assertThat(ex.getMessage(), is("Invalid configuration, workers cannot be 0"));
@@ -140,8 +111,8 @@ public class PipelineConfigurationTests {
             new PipelineConfiguration(
                     validSingleConfiguration(),
                     validSingleConfiguration(),
-                    validSingleConfiguration(),
-                    validSingleConfiguration(),
+                    validMultipleConfiguration(),
+                    validMultipleConfiguration(),
                     TEST_WORKERS, 0);
         } catch (IllegalArgumentException ex) {
             assertThat(ex.getMessage(), is("Invalid configuration, delay cannot be 0"));

--- a/situp-core/src/test/resources/cyclic_multiple_pipeline_configuration.yml
+++ b/situp-core/src/test/resources/cyclic_multiple_pipeline_configuration.yml
@@ -6,19 +6,19 @@ test-pipeline-1:
   buffer:
     bounded_blocking: #to check non object nodes for plugins
   sink:
-    pipeline:
-      name: "test-pipeline-2"
+    - pipeline:
+       name: "test-pipeline-2"
 test-pipeline-2:
   source:
     pipeline:
-      name: "test-pipeline-1"
+       name: "test-pipeline-1"
   sink:
-    pipeline:
-      name: "test-pipeline-3"
+    - pipeline:
+       name: "test-pipeline-3"
 test-pipeline-3:
   source:
     pipeline:
       name: "test-pipeline-2"
   sink:
-    pipeline:
-      name: "test-pipeline-1"
+    - pipeline:
+       name: "test-pipeline-1"

--- a/situp-core/src/test/resources/incorrect_source_multiple_pipeline_configuration.yml
+++ b/situp-core/src/test/resources/incorrect_source_multiple_pipeline_configuration.yml
@@ -5,18 +5,18 @@ test-pipeline-1:
   buffer:
     bounded_blocking: #to check non object nodes for plugins
   sink:
-    pipeline:
-      name: "test-pipeline-2"
+    - pipeline:
+       name: "test-pipeline-2"
 test-pipeline-2:
   source:
     pipeline:
       name: "test-pipeline-4"
   sink:
-    pipeline:
-      name: "test-pipeline-3"
+    - pipeline:
+       name: "test-pipeline-3"
 test-pipeline-3:
   source:
     pipeline:
       name: "test-pipeline-2"
   sink:
-    file:
+    - file:

--- a/situp-core/src/test/resources/missing_name_multiple_pipeline_configuration.yml
+++ b/situp-core/src/test/resources/missing_name_multiple_pipeline_configuration.yml
@@ -6,10 +6,10 @@ test-pipeline-1:
   buffer:
     bounded_blocking: #to check non object nodes for plugins
   sink:
-    pipeline:
+    - pipeline:
 test-pipeline-2:
   source:
     pipeline:
       name: "test-pipeline-1"
   sink:
-    file:
+    - file:

--- a/situp-core/src/test/resources/missing_pipeline_multiple_pipeline_configuration.yml
+++ b/situp-core/src/test/resources/missing_pipeline_multiple_pipeline_configuration.yml
@@ -6,12 +6,12 @@ test-pipeline-1:
   buffer:
     bounded_blocking: #to check non object nodes for plugins
   sink:
-    pipeline:
-      name: "test-pipeline-4"
+    - pipeline:
+       name: "test-pipeline-4"
 test-pipeline-2:
   source:
     pipeline:
-      name: "test-pipeline-1"
+       name: "test-pipeline-1"
   sink:
-    pipeline:
-      name: "test-pipeline-3"
+    - pipeline:
+       name: "test-pipeline-3"

--- a/situp-core/src/test/resources/valid_multiple_pipeline_configuration.yml
+++ b/situp-core/src/test/resources/valid_multiple_pipeline_configuration.yml
@@ -6,19 +6,19 @@ test-pipeline-1:
   buffer:
     bounded_blocking: #to check non object nodes for plugins
   sink:
-    pipeline:
-      name: "test-pipeline-2"
+    - pipeline:
+       name: "test-pipeline-2"
 test-pipeline-2:
   source:
     pipeline:
       name: "test-pipeline-1"
   sink:
-    pipeline:
-      name: "test-pipeline-3"
+    - pipeline:
+       name: "test-pipeline-3"
 test-pipeline-3:
   source:
     pipeline:
       name: "test-pipeline-2"
   sink:
-    file:
-      someProperty: "someValue"
+    - file:
+       someProperty: "someValue"

--- a/situp-core/src/test/resources/valid_multiple_processors.yml
+++ b/situp-core/src/test/resources/valid_multiple_processors.yml
@@ -1,0 +1,28 @@
+entry-pipeline:
+  source:
+    otel_trace_source:
+  sink:
+    - pipeline:
+        name: "raw-pipeline"
+    - pipeline:
+        name: "service-map-pipeline"
+raw-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - upper-case:
+    - upper-case:
+  sink:
+    - file:
+        someProperty: "someValue"
+service-map-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - upper-case:
+    - upper-case:
+  sink:
+    - file:
+        someProperty: "someValue"

--- a/situp-core/src/test/resources/valid_multiple_sinks.yml
+++ b/situp-core/src/test/resources/valid_multiple_sinks.yml
@@ -1,0 +1,26 @@
+entry-pipeline:
+  source:
+    otel_trace_source:
+  sink:
+    - pipeline:
+        name: "raw-pipeline"
+    - pipeline:
+        name: "service-map-pipeline"
+raw-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - upper-case:
+  sink:
+    - file:
+        someProperty: "someValue"
+service-map-pipeline:
+  source:
+    pipeline:
+      name: "entry-pipeline"
+  processor:
+    - upper-case:
+  sink:
+    - file:
+        someProperty: "someValue"


### PR DESCRIPTION
*Issue #47 *


*Description of changes:*

Made the PipelineConfiguration object strict to support. 
* Only one non-null **source**
* Only one optional **buffer**
* Zero or more optional **processors**
* One or more **sinks**






By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
