### PR TITLE
Updating lmdbstate to use file passed in as db, and deleting db files…

### DIFF
--- a/situp-plugins/lmdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/LmdbProcessorStateTest.java
+++ b/situp-plugins/lmdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/LmdbProcessorStateTest.java
@@ -10,6 +10,6 @@ public class LmdbProcessorStateTest extends ProcessorStateTest {
 
     @Override
     public void setProcessorState() throws Exception {
-        this.processorState = new LmdbProcessorState<>(temporaryFolder.newFolder(), "testDb", DataClass.class);
+        this.processorState = new LmdbProcessorState<>(temporaryFolder.newFile(), "testDb", DataClass.class);
     }
 }

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapProcessorConfig.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapProcessorConfig.java
@@ -3,6 +3,5 @@ package com.amazon.situp.plugins.processor;
 public class ServiceMapProcessorConfig {
     static final String WINDOW_DURATION = "window_duration";
     static final int DEFAULT_WINDOW_DURATION = 180;
-    static final String DEFAULT_TRACES_LMDB_PATH = "data/service-map/spans";
-    static final String DEFAULT_SPANS_LMDB_PATH = "data/service-map/traces";
+    static final String DEFAULT_LMDB_PATH = "data/service-map/";
 }

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
@@ -292,14 +292,14 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
      * @return Next database name
      */
     private String getNewDbName() {
-        return "db-" + clock.millis();
+        return "/db-" + clock.millis();
     }
 
     /**
      * @return Next database name
      */
     private String getNewTraceDbName() {
-        return "trace-db-" + clock.millis();
+        return "/trace-db-" + clock.millis();
     }
 
     /**

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 @SitupPlugin(name = "service_map_stateful", type = PluginType.PROCESSOR)
 public class ServiceMapStatefulProcessor implements Processor<Record<ExportTraceServiceRequest>, Record<String>> {
 
+    private static final String EMPTY_SUFFIX = "-empty";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final Collection<Record<String>> EMPTY_COLLECTION = Collections.emptySet();
     private static final Integer TO_MILLIS = 1_000;
@@ -59,9 +60,9 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
             ServiceMapStatefulProcessor.windowDurationMillis = windowDurationMillis;
             ServiceMapStatefulProcessor.dbPath = createPath(databasePath);
             currentWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewDbName())), "spansDb", ServiceMapStateData.class);
-            previousWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewDbName() + "-prev")), "spansDb", ServiceMapStateData.class);
+            previousWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewDbName() + EMPTY_SUFFIX)), "spansDb", ServiceMapStateData.class);
             currentTraceGroupWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewTraceDbName())), "traceDb", String.class);
-            previousTraceGroupWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewTraceDbName() + "-prev")), "traceDb", String.class);
+            previousTraceGroupWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewTraceDbName() + EMPTY_SUFFIX)), "traceDb", String.class);
         }
     }
 

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
@@ -58,10 +58,10 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
             previousTimestamp = ServiceMapStatefulProcessor.clock.millis();
             ServiceMapStatefulProcessor.windowDurationMillis = windowDurationMillis;
             ServiceMapStatefulProcessor.dbPath = createPath(databasePath);
-            currentWindow = new LmdbProcessorState<>(new File(dbPath.getPath() + getNewDbName()), "spansDb", ServiceMapStateData.class);
-            previousWindow = new LmdbProcessorState<>(new File(dbPath.getPath() + getNewDbName() + "-prev"), "spansDb", ServiceMapStateData.class);
-            currentTraceGroupWindow = new LmdbProcessorState<>(new File(dbPath.getPath() + getNewTraceDbName()), "traceDb", String.class);
-            previousTraceGroupWindow = new LmdbProcessorState<>(new File(dbPath.getPath() + getNewTraceDbName() + "-prev"), "traceDb", String.class);
+            currentWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewDbName())), "spansDb", ServiceMapStateData.class);
+            previousWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewDbName() + "-prev")), "spansDb", ServiceMapStateData.class);
+            currentTraceGroupWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewTraceDbName())), "traceDb", String.class);
+            previousTraceGroupWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewTraceDbName() + "-prev")), "traceDb", String.class);
         }
     }
 
@@ -281,9 +281,10 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
         previousWindow.delete();
         previousTraceGroupWindow.delete();
         previousWindow = currentWindow;
-        currentWindow = new LmdbProcessorState(new File(dbPath.getPath() + getNewDbName()), "spansDb", ServiceMapStateData.class);
+        currentWindow = new LmdbProcessorState(new File(String.join("/", dbPath.getPath(), getNewDbName())), "spansDb", ServiceMapStateData.class);
         previousTraceGroupWindow = currentTraceGroupWindow;
-        currentTraceGroupWindow = new LmdbProcessorState<>(new File(dbPath.getPath() + getNewTraceDbName()), "traceDb", String.class);
+        currentTraceGroupWindow = new LmdbProcessorState<>(new File(String.join("/", dbPath.getPath(), getNewTraceDbName())), "traceDb", String.class);
+
         previousTimestamp = clock.millis();
         doneRotatingWindows();
     }
@@ -292,14 +293,14 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
      * @return Next database name
      */
     private String getNewDbName() {
-        return "/db-" + clock.millis();
+        return "db-" + clock.millis();
     }
 
     /**
      * @return Next database name
      */
     private String getNewTraceDbName() {
-        return "/trace-db-" + clock.millis();
+        return "trace-db-" + clock.millis();
     }
 
     /**

--- a/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -59,7 +59,7 @@ public class ServiceMapStatefulProcessorTest {
         final Clock clock = Mockito.mock(Clock.class);
         Mockito.when(clock.millis()).thenReturn(1L);
         ExecutorService threadpool = Executors.newCachedThreadPool();
-        final File path = temporaryFolder.newFolder();
+        final File path = new File(ServiceMapProcessorConfig.DEFAULT_LMDB_PATH);
         final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, clock);
         final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, clock);
 

--- a/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -60,9 +60,8 @@ public class ServiceMapStatefulProcessorTest {
         Mockito.when(clock.millis()).thenReturn(1L);
         ExecutorService threadpool = Executors.newCachedThreadPool();
         final File path = temporaryFolder.newFolder();
-        final File path2 = temporaryFolder.newFolder();
-        final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, path2, clock);
-        final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, path2, clock);
+        final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, clock);
+        final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, clock);
 
         final byte[] rootSpanId1 = ServiceMapTestUtils.getRandomBytes(8);
         final byte[] rootSpanId2 = ServiceMapTestUtils.getRandomBytes(8);
@@ -177,6 +176,7 @@ public class ServiceMapStatefulProcessorTest {
         Future<Set<ServiceMapRelationship>> r10 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2, Arrays.asList());
         Assert.assertTrue(r9.get().isEmpty());
         Assert.assertTrue(r10.get().isEmpty());
+        serviceMapStateful1.deleteState();
     }
 
     private static class ServiceMapSourceDest {


### PR DESCRIPTION
… on rotation

*Issue #, if available:*

*Description of changes:*

- Using the MDB_NOSUBDIR flag on the lmdb database creation. This allows you to pass in a File that corresponds to the database file to use (lock file is created as databaseFile + "-lock")
- Deleting database and lock files on window rotation
- Only passing in a single database path directory now, because all databases will be created as database files with unique names in that directory



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
