### PR TITLE
Adding MapDB processor state and using it in Service Map Stateful Processor

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -8,3 +8,5 @@ include 'situp-plugins:apmtracesource'
 include 'situp-plugins:elasticsearch'
 include 'situp-plugins:lmdb-processor-state'
 include 'situp-plugins:service-map-stateful'
+include 'situp-plugins:mapdb-processor-state'
+

--- a/situp-api/src/main/java/com/amazon/situp/processor/state/ProcessorState.java
+++ b/situp-api/src/main/java/com/amazon/situp/processor/state/ProcessorState.java
@@ -40,6 +40,16 @@ public interface ProcessorState<K, V> {
     public<R> List<R> iterate(BiFunction<K, V, R> fn);
 
     /**
+     * Iterate over a segment of the processor state with a bifunction
+     * @param fn BiFunction with which to iterate over the processor state
+     * @param segments total number of segments
+     * @param index segment index
+     * @param <R> Type parameter for return value of BiFunction
+     * @return Result of iteration as a list of objects of type R
+     */
+    public<R> List<R> iterate(BiFunction<K, V, R> fn, int segments, int index);
+
+    /**
      * @return Size of the processor state, in terms of number of elements stored.
      */
     public long size();

--- a/situp-api/src/main/java/com/amazon/situp/processor/state/ProcessorState.java
+++ b/situp-api/src/main/java/com/amazon/situp/processor/state/ProcessorState.java
@@ -55,12 +55,7 @@ public interface ProcessorState<K, V> {
     public long size();
 
     /**
-     * Clears the data in the processor state
-     */
-    void clear();
-
-    /**
      * Any cleanup code goes here
      */
-    void close();
+    void delete();
 }

--- a/situp-plugins/common/src/test/java/com/amazon/situp/plugins/processor/state/ProcessorStateTest.java
+++ b/situp-plugins/common/src/test/java/com/amazon/situp/plugins/processor/state/ProcessorStateTest.java
@@ -1,13 +1,11 @@
 package com.amazon.situp.plugins.processor.state;
 
 import com.amazon.situp.processor.state.ProcessorState;
+
+import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import org.junit.After;

--- a/situp-plugins/common/src/test/java/com/amazon/situp/plugins/processor/state/ProcessorStateTest.java
+++ b/situp-plugins/common/src/test/java/com/amazon/situp/plugins/processor/state/ProcessorStateTest.java
@@ -77,8 +77,7 @@ public abstract class ProcessorStateTest {
 
     @After
     public void teardown() {
-        processorState.clear();
-        processorState.close();
+        processorState.delete();
     }
 
     @Test

--- a/situp-plugins/common/src/test/java/com/amazon/situp/plugins/processor/state/ProcessorStateTest.java
+++ b/situp-plugins/common/src/test/java/com/amazon/situp/plugins/processor/state/ProcessorStateTest.java
@@ -1,17 +1,15 @@
 package com.amazon.situp.plugins.processor.state;
 
 import com.amazon.situp.processor.state.ProcessorState;
-
-import java.io.IOException;
-import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.Serializable;
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 public abstract class ProcessorStateTest {
 

--- a/situp-plugins/mapdb-processor-state/build.gradle
+++ b/situp-plugins/mapdb-processor-state/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+    id 'java'
+}
+
+group 'com.amazon'
+version '0.1-beta'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+    compile project(':situp-api')
+    compile project(':situp-plugins:common')
+    compile 'org.mapdb:mapdb:3.0.8'
+    testCompile project(':situp-plugins:common').sourceSets.test.output
+    testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"
+}

--- a/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java
+++ b/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java
@@ -1,0 +1,115 @@
+package com.amazon.situp.plugins.processor.state;
+
+import com.google.common.primitives.SignedBytes;
+import com.amazon.situp.processor.state.ProcessorState;
+import java.io.File;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.mapdb.BTreeMap;
+import org.mapdb.DBMaker;
+import org.mapdb.Serializer;
+import org.mapdb.serializer.SerializerByteArray;
+
+public class MapDbProcessorState<V> implements ProcessorState<byte[], V> {
+
+
+    private static class SignedByteArraySerializer extends SerializerByteArray {
+        @Override
+        public int compare(byte[] o1, byte[] o2) {
+            return SignedBytes.lexicographicalComparator().compare(o1, o2);
+        }
+    }
+
+    private static final SignedByteArraySerializer SIGNED_BYTE_ARRAY_SERIALIZER = new SignedByteArraySerializer();
+
+    private final BTreeMap<byte[], V> map;
+
+    public MapDbProcessorState(final File dbPath, final String dbName) {
+        map = (BTreeMap<byte[], V>) DBMaker.fileDB(String.join("/", dbPath.getPath(), dbName)).closeOnJvmShutdown().fileDeleteAfterClose().fileMmapEnable().fileMmapPreclearDisable().make()
+                .treeMap(dbName).counterEnable().keySerializer(SIGNED_BYTE_ARRAY_SERIALIZER).valueSerializer(Serializer.JAVA).create();
+    }
+
+
+    @Override
+    public void put(byte[] key, V value) {
+        map.put(key, value);
+    }
+
+    public void putAll(final Map<byte[], V> data) {
+        map.putAll(data);
+    }
+
+    @Override
+    public V get(byte[] key) {
+        return map.get(key);
+    }
+
+    @Override
+    public Map<byte[], V> getAll() {
+        return map;
+    }
+
+    @Override
+    public <R> List<R> iterate(BiFunction<byte[], V, R> fn) {
+        final List<R> returnList = new ArrayList<>();
+        map.entryIterator().forEachRemaining(
+                entry -> returnList.add(fn.apply(entry.getKey(), entry.getValue()))
+        );
+        return returnList;
+    }
+
+    //TODO: Make this function an interface method, because it can be used to split iteration without knowing about the underlying structure
+    public <R> List<R> iterate(BiFunction<byte[], V, R> fn, final int segments, final int index) {
+        if(map.size() == 0) {
+            return Collections.EMPTY_LIST;
+        }
+        final List<byte[]> iterationEndpoints = getIterationEndpoints(segments, index);
+        final List<R> returnList = new ArrayList<>();
+        map.entryIterator(iterationEndpoints.get(0), true, iterationEndpoints.get(1), false).forEachRemaining(
+                entry -> returnList.add(fn.apply(entry.getKey(), entry.getValue()))
+        );
+        return returnList;
+    }
+
+    private List<byte[]> getIterationEndpoints(final int segments, final int index) {
+        final BigInteger lowEnd = new BigInteger(map.firstKey());
+        final BigInteger highEnd = new BigInteger(map.lastKey());
+        final BigInteger step = highEnd.subtract(lowEnd).divide(new BigInteger(String.valueOf(segments)));
+        final byte[] lowIndex = lowEnd.add(step.multiply(new BigInteger(String.valueOf(index)))).toByteArray();
+        final byte[] highIndex = index == segments - 1? highEnd.add(new BigInteger("1")).toByteArray() : lowEnd.add(step.multiply(new BigInteger(String.valueOf(index+1)))).toByteArray();
+        final List<byte[]> iterationEndpoints = new ArrayList<>();
+        iterationEndpoints.add(lowIndex);
+        iterationEndpoints.add(highIndex);
+
+        return iterationEndpoints;
+    }
+
+    private String bytesToString(final byte[] bytes) {
+        String s = "[";
+        for(int i=0; i<bytes.length; i++) {
+            s += bytes[i] + " , ";
+        }
+        s += "]";
+        return s;
+    }
+
+
+    @Override
+    public long size() {
+        return map.size();
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public void close() {
+        map.close();
+    }
+}

--- a/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java
+++ b/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java
@@ -29,8 +29,15 @@ public class MapDbProcessorState<V> implements ProcessorState<byte[], V> {
     private final BTreeMap<byte[], V> map;
 
     public MapDbProcessorState(final File dbPath, final String dbName) {
-        map = (BTreeMap<byte[], V>) DBMaker.fileDB(String.join("/", dbPath.getPath(), dbName)).closeOnJvmShutdown().fileDeleteAfterClose().fileMmapEnable().fileMmapPreclearDisable().make()
-                .treeMap(dbName).counterEnable().keySerializer(SIGNED_BYTE_ARRAY_SERIALIZER).valueSerializer(Serializer.JAVA).create();
+        map =
+                (BTreeMap<byte[], V>) DBMaker.fileDB(String.join("/", dbPath.getPath(), dbName))
+                        .fileDeleteAfterClose()
+                        .fileMmapEnable() //MapDB uses the (slower) Random Access Files by default
+                        .make()
+                        .treeMap(dbName)
+                        .counterEnable() //Treemap doesnt keep size counter by default
+                        .keySerializer(SIGNED_BYTE_ARRAY_SERIALIZER)
+                        .valueSerializer(Serializer.JAVA).create();
     }
 
 

--- a/situp-plugins/mapdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/MapDbProcessorStateTest.java
+++ b/situp-plugins/mapdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/MapDbProcessorStateTest.java
@@ -1,0 +1,67 @@
+package com.amazon.situp.plugins.processor.state;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class MapDbProcessorStateTest extends ProcessorStateTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Override
+    public void setProcessorState() throws Exception {
+        this.processorState = new MapDbProcessorState<>(temporaryFolder.newFolder(), "testDb");
+    }
+
+    @Test
+    public void testIterateSegment() throws IOException {
+        final byte[] key1  = new byte[]{-64, 0, -64, 0};
+        final byte[] key2 = new byte[]{0};
+        final byte[] key3 = new byte[]{64, 64, 64 , 64};
+        final byte[] key4 = new byte[]{126, 126, 126, 126};
+
+        final DataClass data1 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
+        final DataClass data2 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
+        final DataClass data3 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
+        final DataClass data4 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
+
+        processorState.put(key3, data3);
+        processorState.put(key4, data4);
+        processorState.put(key1, data1);
+        processorState.put(key2, data2);
+
+        final List<String> values = processorState.iterate(new BiFunction<byte[], DataClass, String>() {
+            @Override
+            public String apply(byte[] bytes, DataClass s) {
+                return s.stringVal;
+            }
+        }, 2, 0);
+
+        final List<String> values2 = processorState.iterate(new BiFunction<byte[], DataClass, String>() {
+            @Override
+            public String apply(byte[] bytes, DataClass s) {
+                return s.stringVal;
+            }
+        }, 2, 1);
+
+        Assert.assertEquals(2, values.size());
+        Assert.assertEquals(2, values2.size());
+        Assert.assertTrue(values.containsAll(Arrays.asList(
+                data1.stringVal,
+                data2.stringVal
+        )));
+        Assert.assertTrue(values2.containsAll(Arrays.asList(
+                data3.stringVal,
+                data4.stringVal
+        )));
+
+    }
+
+}

--- a/situp-plugins/service-map-stateful/build.gradle
+++ b/situp-plugins/service-map-stateful/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     compile project(':situp-api')
     compile project(':situp-plugins:common')
     compile project(':situp-plugins:lmdb-processor-state')
+    compile project(':situp-plugins:mapdb-processor-state')
     implementation "com.fasterxml.jackson.core:jackson-databind:${versionMap.jackson_databind}"
     implementation "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
     testImplementation "org.hamcrest:hamcrest:${versionMap.hamcrest}"

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
@@ -5,14 +5,12 @@ import com.amazon.situp.model.annotations.SitupPlugin;
 import com.amazon.situp.model.configuration.PluginSetting;
 import com.amazon.situp.model.processor.Processor;
 import com.amazon.situp.model.record.Record;
-import com.amazon.situp.plugins.processor.state.LmdbProcessorState;
 import com.amazon.situp.plugins.processor.state.MapDbProcessorState;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.primitives.SignedBytes;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 
-import javax.management.MBeanAttributeInfo;
 import java.io.File;
 import java.io.Serializable;
 import java.time.Clock;
@@ -22,6 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 @SitupPlugin(name = "service_map_stateful", type = PluginType.PROCESSOR)
 public class ServiceMapStatefulProcessor implements Processor<Record<ExportTraceServiceRequest>, Record<String>> {
 
@@ -322,13 +321,6 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
     private boolean isMasterInstance() {
         return thisProcessorId == 0;
     }
-
-    /**
-     * Getting range for this processor given a number of elements
-     * @param elements Elements to iterate over
-     * @return Range given as a 2 element array of longs
-     */
-
 
     private static class ServiceMapStateData implements Serializable {
         public String serviceName;

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
@@ -222,20 +222,12 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
         return traceGroupName != null ? traceGroupName : previousTraceGroupWindow.get(traceId);
     }
 
-    /**
-     * Delete current state held in the processor
-     */
-    public void deleteState() {
-        previousTraceGroupWindow.close();
-        currentTraceGroupWindow.close();
-        previousWindow.close();
-        currentWindow.close();
-    }
-
     //TODO: Change to an override when a shutdown method is added to the processor interface
     public void shutdown() {
-        previousWindow.close();
-        currentWindow.close();
+        previousWindow.delete();
+        currentWindow.delete();
+        previousTraceGroupWindow.delete();
+        currentTraceGroupWindow.delete();
     }
 
     /**
@@ -280,8 +272,8 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
      * Rotate windows for processor state
      */
     private void rotateWindows() {
-        previousWindow.close();
-        previousTraceGroupWindow.close();
+        previousWindow.delete();
+        previousTraceGroupWindow.delete();
         previousWindow = currentWindow;
         currentWindow = new MapDbProcessorState<>(dbPath, getNewDbName());
         previousTraceGroupWindow = currentTraceGroupWindow;

--- a/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -176,7 +176,7 @@ public class ServiceMapStatefulProcessorTest {
         Future<Set<ServiceMapRelationship>> r10 = ServiceMapTestUtils.startExecuteAsync(threadpool, serviceMapStateful2, Arrays.asList());
         Assert.assertTrue(r9.get().isEmpty());
         Assert.assertTrue(r10.get().isEmpty());
-        serviceMapStateful1.deleteState();
+        serviceMapStateful1.shutdown();
     }
 
     private static class ServiceMapSourceDest {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Adding MapDB processor state plugin
- Using this plugin in the service map stateful processor
- Adding new, more generic, interface method for iterating over segments in processor state


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
