### PR TITLE
Adding LMDB and ServiceMapStateful benchmarks

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,6 @@ include 'situp-plugins:service-map-stateful'
 include 'situp-plugins:mapdb-processor-state'
 include 'situp-benchmarks'
 include 'situp-benchmarks:mapdb-benchmarks'
+include 'situp-benchmarks:lmdb-benchmarks'
+include 'situp-benchmarks:service-map-stateful-benchmarks'
 

--- a/situp-benchmarks/lmdb-benchmarks/build.gradle
+++ b/situp-benchmarks/lmdb-benchmarks/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'java'
+    id "me.champeau.gradle.jmh" version "0.5.0"
+}
+
+group 'com.amazon'
+version '0.1-beta'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':situp-plugins:lmdb-processor-state')
+}

--- a/situp-benchmarks/lmdb-benchmarks/src/jmh/java/com/amazon/situp/benchmarks/processor/state/LmdbProcessorStateBenchmarks.java
+++ b/situp-benchmarks/lmdb-benchmarks/src/jmh/java/com/amazon/situp/benchmarks/processor/state/LmdbProcessorStateBenchmarks.java
@@ -1,6 +1,6 @@
 package com.amazon.situp.benchmarks.processor.state;
 
-import com.amazon.situp.plugins.processor.state.MapDbProcessorState;
+import com.amazon.situp.plugins.processor.state.LmdbProcessorState;
 import com.google.common.primitives.SignedBytes;
 import org.openjdk.jmh.annotations.*;
 
@@ -8,14 +8,14 @@ import java.io.File;
 import java.util.*;
 
 @State(Scope.Benchmark)
-public class MapDbProcessorStateBenchmarks {
+public class LmdbProcessorStateBenchmarks {
     private static final int BATCH_SIZE = 100;
     private static final int NUM_BATCHES = 10000;
     private static final Random RANDOM = new Random();
     private static final String DB_PATH = "data/benchmark";
     private static final String DB_NAME = "benchmarkDb";
 
-    private MapDbProcessorState<String> mapDbProcessorState;
+    private LmdbProcessorState<String> lmdbProcessorState;
     private List<Map<byte[], String>> data = new ArrayList<Map<byte[], String>>(){{
         for(int i=0; i<NUM_BATCHES; i++) {
             final TreeMap<byte[], String> batch = new TreeMap<>(SignedBytes.lexicographicalComparator());
@@ -40,13 +40,12 @@ public class MapDbProcessorStateBenchmarks {
                 throw new RuntimeException(String.format("Unable to create the directory at the provided path: %s", path.getName()));
             }
         }
-        mapDbProcessorState = new MapDbProcessorState<>(new File(DB_PATH), DB_NAME);
-
+        lmdbProcessorState = new LmdbProcessorState<>(new File(String.join("/", DB_PATH, DB_NAME)), DB_NAME, String.class);
     }
 
     @TearDown(Level.Iteration)
     public void teardown() {
-        mapDbProcessorState.delete();
+        lmdbProcessorState.delete();
     }
 
     @Benchmark
@@ -55,8 +54,7 @@ public class MapDbProcessorStateBenchmarks {
     @Threads(value = 2)
     @Measurement(iterations = 5)
     public void benchmarkPutAll() {
-        mapDbProcessorState.putAll(data.get(RANDOM.nextInt(NUM_BATCHES)));
+        lmdbProcessorState.putAll(data.get(RANDOM.nextInt(NUM_BATCHES)));
     }
-
 
 }

--- a/situp-benchmarks/service-map-stateful-benchmarks/build.gradle
+++ b/situp-benchmarks/service-map-stateful-benchmarks/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'java'
+    id "me.champeau.gradle.jmh" version "0.5.0"
+}
+
+group 'com.amazon'
+version '0.1-beta'
+
+sourceCompatibility = 1.8
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile project(':situp-plugins:service-map-stateful')
+    jmh "io.opentelemetry:opentelemetry-proto:${versionMap.opentelemetry_proto}"
+}

--- a/situp-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/situp/benchmarks/processor/ServiceMapStatefulProcessorBenchmarks.java
+++ b/situp-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/situp/benchmarks/processor/ServiceMapStatefulProcessorBenchmarks.java
@@ -1,0 +1,118 @@
+package com.amazon.situp.benchmarks.processor;
+
+import com.google.protobuf.ByteString;
+import com.amazon.situp.model.record.Record;
+import com.amazon.situp.plugins.processor.OTelHelper;
+import com.amazon.situp.plugins.processor.ServiceMapStatefulProcessor;
+import java.io.File;
+import java.io.UnsupportedEncodingException;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.common.v1.AnyValue;
+import io.opentelemetry.proto.common.v1.KeyValue;
+import io.opentelemetry.proto.resource.v1.Resource;
+import io.opentelemetry.proto.trace.v1.InstrumentationLibrarySpans;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import io.opentelemetry.proto.trace.v1.Span;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Thread)
+public class ServiceMapStatefulProcessorBenchmarks {
+
+    private ServiceMapStatefulProcessor serviceMapStatefulProcessor;
+    private List<List<Record<ExportTraceServiceRequest>>> batches;
+    private static final String DB_PATH = "data/benchmark";
+    private static final int BATCH_SIZE = 100;
+    private static final int NUM_BATCHES = 1000;
+    private static final Random RANDOM = new Random();
+    private static final List<String> serviceNames = Arrays.asList("FRONTEND", "BACKEND", "PAYMENT", "CHECKOUT", "DATABASE");
+
+    @Setup(Level.Trial)
+    public void setupServiceMapStatefulProcessor() {
+        serviceMapStatefulProcessor = new ServiceMapStatefulProcessor(1000, new File(DB_PATH), Clock.systemDefaultZone());
+    }
+
+    @Setup(Level.Trial)
+    public void setupBatches() throws UnsupportedEncodingException {
+        batches = new ArrayList<>();
+        for(int i=0; i<NUM_BATCHES; i++) {
+            List<Record<ExportTraceServiceRequest>> batch = new ArrayList<>();
+            for(int j=0; j<BATCH_SIZE; j++) {
+                batch.add(new Record<>(getExportTraceServiceRequest(
+                        getResourceSpans(
+                                serviceNames.get(RANDOM.nextInt(serviceNames.size())),
+                                UUID.randomUUID().toString(),
+                                getRandomBytes(8),
+                                getRandomBytes(8),
+                                getRandomBytes(16),
+                                Span.SpanKind.CLIENT
+                ))));
+            }
+            batches.add(batch);
+        }
+    }
+
+    @Benchmark
+    @Fork(value = 1)
+    @Warmup(iterations = 3)
+    @Threads(value = 8)
+    @Measurement(iterations = 5)
+    public void benchmarkExecute() {
+        serviceMapStatefulProcessor.execute(batches.get(RANDOM.nextInt(NUM_BATCHES)));
+    }
+
+    private static byte[] getRandomBytes(int len) {
+        byte[] bytes = new byte[len];
+        RANDOM.nextBytes(bytes);
+        return bytes;
+    }
+
+    public static ResourceSpans getResourceSpans(final String serviceName, final String spanName, final byte[]
+            spanId, final byte[] parentId, final byte[] traceId, final Span.SpanKind spanKind) throws UnsupportedEncodingException {
+        final ByteString parentSpanId = parentId != null ? ByteString.copyFrom(parentId) : ByteString.EMPTY;
+        return ResourceSpans.newBuilder()
+                .setResource(
+                        Resource.newBuilder()
+                                .addAttributes(KeyValue.newBuilder()
+                                        .setKey("service.name")
+                                        .setValue(AnyValue.newBuilder().setStringValue(serviceName).build()).build())
+                                .build()
+                )
+                .addInstrumentationLibrarySpans(
+                        0,
+                        InstrumentationLibrarySpans.newBuilder()
+                                .addSpans(
+                                        Span.newBuilder()
+                                                .setName(spanName)
+                                                .setKind(spanKind)
+                                                .setSpanId(ByteString.copyFrom(spanId))
+                                                .setParentSpanId(parentSpanId)
+                                                .setTraceId(ByteString.copyFrom(traceId))
+                                                .build()
+                                )
+                                .build()
+                )
+                .build();
+    }
+
+    public static ExportTraceServiceRequest getExportTraceServiceRequest(ResourceSpans...spans){
+        return ExportTraceServiceRequest.newBuilder()
+                .addAllResourceSpans(Arrays.asList(spans))
+                .build();
+    }
+
+}

--- a/situp-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/situp/benchmarks/processor/ServiceMapStatefulProcessorBenchmarks.java
+++ b/situp-benchmarks/service-map-stateful-benchmarks/src/jmh/java/com/amazon/situp/benchmarks/processor/ServiceMapStatefulProcessorBenchmarks.java
@@ -9,8 +9,11 @@ import java.io.UnsupportedEncodingException;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.common.v1.AnyValue;
@@ -35,19 +38,48 @@ public class ServiceMapStatefulProcessorBenchmarks {
 
     private ServiceMapStatefulProcessor serviceMapStatefulProcessor;
     private List<List<Record<ExportTraceServiceRequest>>> batches;
+    private List<byte[]> spanIds;
+    private List<byte[]> traceIds;
     private static final String DB_PATH = "data/benchmark";
     private static final int BATCH_SIZE = 100;
     private static final int NUM_BATCHES = 1000;
     private static final Random RANDOM = new Random();
     private static final List<String> serviceNames = Arrays.asList("FRONTEND", "BACKEND", "PAYMENT", "CHECKOUT", "DATABASE");
+    private static final List<String> traceGroups = Arrays.asList("tg1", "tg2", "tg3", "tg4", "tg5", "tg6", "tg7", "tg8", "tg9");
 
     @Setup(Level.Trial)
     public void setupServiceMapStatefulProcessor() {
         serviceMapStatefulProcessor = new ServiceMapStatefulProcessor(1000, new File(DB_PATH), Clock.systemDefaultZone());
     }
 
+    private byte[] getTraceId() {
+        if(RANDOM.nextInt(100) < 10 || traceIds.isEmpty()) {
+            final byte[] traceId = getRandomBytes(16);
+            traceIds.add(traceId);
+            return traceId;
+        } else {
+            return traceIds.get(RANDOM.nextInt(traceIds.size()));
+        }
+    }
+
+    private byte[] getSpanId() {
+        final byte[] spanId = getRandomBytes(8);
+        spanIds.add(spanId);
+        return spanId;
+    }
+
+    private byte[] getParentId() {
+        if(RANDOM.nextInt(1000) == 0 || spanIds.isEmpty()) {
+            return null;
+        } else {
+            return spanIds.get(RANDOM.nextInt(spanIds.size()));
+        }
+    }
+
     @Setup(Level.Trial)
     public void setupBatches() throws UnsupportedEncodingException {
+        spanIds = new ArrayList<>();
+        traceIds = new ArrayList<>();
         batches = new ArrayList<>();
         for(int i=0; i<NUM_BATCHES; i++) {
             List<Record<ExportTraceServiceRequest>> batch = new ArrayList<>();
@@ -55,10 +87,10 @@ public class ServiceMapStatefulProcessorBenchmarks {
                 batch.add(new Record<>(getExportTraceServiceRequest(
                         getResourceSpans(
                                 serviceNames.get(RANDOM.nextInt(serviceNames.size())),
-                                UUID.randomUUID().toString(),
-                                getRandomBytes(8),
-                                getRandomBytes(8),
-                                getRandomBytes(16),
+                                traceGroups.get(RANDOM.nextInt(traceGroups.size())),
+                                getSpanId(),
+                                getParentId(),
+                                getTraceId(),
                                 Span.SpanKind.CLIENT
                 ))));
             }
@@ -69,7 +101,7 @@ public class ServiceMapStatefulProcessorBenchmarks {
     @Benchmark
     @Fork(value = 1)
     @Warmup(iterations = 3)
-    @Threads(value = 8)
+    @Threads(value = 2)
     @Measurement(iterations = 5)
     public void benchmarkExecute() {
         serviceMapStatefulProcessor.execute(batches.get(RANDOM.nextInt(NUM_BATCHES)));

--- a/situp-plugins/lmdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/LmdbProcessorStateTest.java
+++ b/situp-plugins/lmdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/LmdbProcessorStateTest.java
@@ -1,7 +1,13 @@
 package com.amazon.situp.plugins.processor.state;
 
+import org.junit.Assert;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 public class LmdbProcessorStateTest extends ProcessorStateTest {
 
@@ -11,5 +17,27 @@ public class LmdbProcessorStateTest extends ProcessorStateTest {
     @Override
     public void setProcessorState() throws Exception {
         this.processorState = new LmdbProcessorState<>(temporaryFolder.newFile(), "testDb", DataClass.class);
+    }
+
+    @Test
+    public void testPutAll() {
+        final byte[] key1 = new byte[8];
+        random.nextBytes(key1);
+        final byte[] key2 = new byte[8];
+        random.nextBytes(key2);
+
+        DataClass value1 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
+        DataClass value2 = new DataClass(UUID.randomUUID().toString(), random.nextInt());
+
+        final Map<byte[], DataClass> batch = new HashMap<byte[], DataClass>(){{
+            put(key1, value1);
+            put(key2, value2);
+        }};
+
+        ((LmdbProcessorState)processorState).putAll(batch);
+
+        Assert.assertEquals(value1, processorState.get(key1));
+        Assert.assertEquals(value2, processorState.get(key2));
+
     }
 }

--- a/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
+++ b/situp-plugins/service-map-stateful/src/main/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessor.java
@@ -53,7 +53,7 @@ public class ServiceMapStatefulProcessor implements Processor<Record<ExportTrace
              Clock.systemUTC());
     }
 
-    ServiceMapStatefulProcessor(final long windowDurationMillis,
+    public ServiceMapStatefulProcessor(final long windowDurationMillis,
                                        final File databasePath,
                                        final Clock clock) {
         ServiceMapStatefulProcessor.clock = clock;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adding lmdb putAll method, unit test for that method, and benchmark in the same fashion as MapDB
- Adding service map stateful benchmarks
  - Had to make constructor public for service map stateful processor
  - Data is generated to produce edges every iteration. Tested by printing edges after every iteration (but removed for the commit)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
