### PR TITLE
Include number_of_shards and number_of_replicas.

### DIFF
--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -15,204 +14,205 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class IndexConfiguration {
-  /**
-   * TODO: add index management policy parameters
-   */
-  public static final String SETTINGS = "settings";
-  public static final String TRACE_ANALYTICS_RAW_FLAG = "trace_analytics_raw";
-  public static final String TRACE_ANALYTICS_SERVICE_MAP_FLAG = "trace_analytics_service_map";
-  public static final String INDEX_ALIAS = "index";
-  public static final String TEMPLATE_FILE = "template_file";
-  public static final String NUM_SHARDS = "number_of_shards";
-  public static final String NUM_REPLICAS = "number_of_replicas";
-  public static final String BULK_SIZE = "bulk_size";
-  public static final String DOCUMENT_ID_FIELD = "document_id_field";
-  public static final long DEFAULT_BULK_SIZE = 5L;
+    /**
+     * TODO: add index management policy parameters
+     */
+    public static final String SETTINGS = "settings";
+    public static final String TRACE_ANALYTICS_RAW_FLAG = "trace_analytics_raw";
+    public static final String TRACE_ANALYTICS_SERVICE_MAP_FLAG = "trace_analytics_service_map";
+    public static final String INDEX_ALIAS = "index";
+    public static final String TEMPLATE_FILE = "template_file";
+    public static final String NUM_SHARDS = "number_of_shards";
+    public static final String NUM_REPLICAS = "number_of_replicas";
+    public static final String BULK_SIZE = "bulk_size";
+    public static final String DOCUMENT_ID_FIELD = "document_id_field";
+    public static final long DEFAULT_BULK_SIZE = 5L;
 
-  private final String indexType;
-  private final String indexAlias;
-  private final Map<String, Object> indexTemplate;
-  private final String documentIdField;
-  private final long bulkSize;
+    private final String indexType;
+    private final String indexAlias;
+    private final Map<String, Object> indexTemplate;
+    private final String documentIdField;
+    private final long bulkSize;
 
-  public String getIndexType() {
-    return indexType;
-  }
+    @SuppressWarnings("unchecked")
+    private IndexConfiguration(final Builder builder) {
+        final String indexType;
+        if (builder.isRaw && builder.isServiceMap) {
+            throw new IllegalStateException("trace_analytics_raw and trace_analytics_service_map cannot be both true.");
+        } else if (builder.isRaw) {
+            indexType = IndexConstants.RAW;
+        } else if (builder.isServiceMap) {
+            indexType = IndexConstants.SERVICE_MAP;
+        } else {
+            indexType = IndexConstants.CUSTOM;
+        }
+        this.indexType = indexType;
 
-  public String getIndexAlias() {
-    return indexAlias;
-  }
+        this.indexTemplate = readIndexTemplate(builder.templateFile, indexType);
 
-  public Map<String, Object> getIndexTemplate() {
-    return indexTemplate;
-  }
+        if (builder.numReplicas > 0) {
+            indexTemplate.putIfAbsent(SETTINGS, new HashMap<>());
+            ((Map<String, Object>) indexTemplate.get(SETTINGS)).putIfAbsent(NUM_REPLICAS, builder.numReplicas);
+        }
 
-  public String getDocumentIdField() {
-    return documentIdField;
-  }
+        if (builder.numShards > 0) {
+            indexTemplate.putIfAbsent(SETTINGS, new HashMap<>());
+            ((Map<String, Object>) indexTemplate.get(SETTINGS)).putIfAbsent(NUM_SHARDS, builder.numShards);
+        }
 
-  public long getBulkSize() {
-    return bulkSize;
-  }
+        String indexAlias = builder.indexAlias;
+        if (IndexConstants.TYPE_TO_DEFAULT_ALIAS.containsKey(indexType)) {
+            indexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(indexType);
+        } else {
+            if (indexAlias == null) {
+                throw new IllegalStateException("Missing required properties:indexAlias");
+            }
+        }
+        this.indexAlias = indexAlias;
+        this.bulkSize = builder.bulkSize;
 
-  public static class Builder {
-    private boolean isRaw = false;
-    private boolean isServiceMap = false;
-    private String indexAlias;
-    private String templateFile;
-    private int numShards;
-    private int numReplicas;
-    private String documentIdField;
-    private long bulkSize = DEFAULT_BULK_SIZE;
-
-    public Builder setIsRaw(final Boolean isRaw) {
-      checkNotNull(isRaw, "trace_analytics_raw cannot be null.");
-      this.isRaw = isRaw;
-      return this;
+        String documentIdField = builder.documentIdField;
+        if (indexType.equals(IndexConstants.RAW)) {
+            documentIdField = "spanId";
+        } else if (indexType.equals(IndexConstants.SERVICE_MAP)) {
+            documentIdField = "hashId";
+        }
+        this.documentIdField = documentIdField;
     }
 
-    public Builder setIsServiceMap(final Boolean isServiceMap) {
-      checkNotNull(isServiceMap, "trace_analytics_service_map cannot be null.");
-      this.isServiceMap = isServiceMap;
-      return this;
+    public static IndexConfiguration readIndexConfig(final PluginSetting pluginSetting) {
+        IndexConfiguration.Builder builder = new IndexConfiguration.Builder();
+        builder.setIsRaw(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_RAW_FLAG, false));
+        builder.setIsServiceMap(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_SERVICE_MAP_FLAG, false));
+        final String indexAlias = pluginSetting.getStringOrDefault(INDEX_ALIAS, null);
+        if (indexAlias != null) {
+            builder = builder.withIndexAlias(indexAlias);
+        }
+        final String templateFile = pluginSetting.getStringOrDefault(TEMPLATE_FILE, null);
+        if (templateFile != null) {
+            builder = builder.withTemplateFile(templateFile);
+        }
+        builder = builder.withNumShards(pluginSetting.getIntegerOrDefault(NUM_SHARDS, 0));
+        builder = builder.withNumShards(pluginSetting.getIntegerOrDefault(NUM_REPLICAS, 0));
+        final Long batchSize = pluginSetting.getLongOrDefault(BULK_SIZE, DEFAULT_BULK_SIZE);
+        builder = builder.withBulkSize(batchSize);
+        final String documentId = pluginSetting.getStringOrDefault(DOCUMENT_ID_FIELD, null);
+        if (documentId != null) {
+            builder = builder.withDocumentIdField(documentId);
+        }
+        return builder.build();
     }
 
-    public Builder withIndexAlias(final String indexAlias) {
-      checkArgument(indexAlias != null, "indexAlias cannot be null.");
-      checkArgument(!indexAlias.isEmpty(), "indexAlias cannot be empty");
-      this.indexAlias = indexAlias;
-      return this;
+    public String getIndexType() {
+        return indexType;
     }
 
-    public Builder withTemplateFile(final String templateFile) {
-      checkArgument(templateFile != null, "templateFile cannot be null.");
-      this.templateFile = templateFile;
-      return this;
+    public String getIndexAlias() {
+        return indexAlias;
     }
 
-    public Builder withDocumentIdField(final String documentIdField) {
-      checkNotNull(documentIdField, "documentId field cannot be null");
-      this.documentIdField = documentIdField;
-      return this;
+    public Map<String, Object> getIndexTemplate() {
+        return indexTemplate;
     }
 
-    public Builder withBulkSize(final long bulkSize) {
-      this.bulkSize = bulkSize;
-      return this;
+    public String getDocumentIdField() {
+        return documentIdField;
     }
 
-    public Builder withNumShards(final int numShards) {
-      this.numShards = numShards;
-      return this;
+    public long getBulkSize() {
+        return bulkSize;
     }
 
-    public Builder withNumReplicas(final int numReplicas) {
-      this.numReplicas = numReplicas;
-      return this;
+    /**
+     * This method is used in the creation of IndexConfiguration object. It takes in the template file path
+     * or index type and returns the index template read from the file or specific to index type or returns an
+     * empty map.
+     *
+     * @param templateFile
+     * @param indexType
+     * @return
+     */
+    private Map<String, Object> readIndexTemplate(final String templateFile, final String indexType) {
+        try {
+            URL templateURL = null;
+            if (indexType.equals(IndexConstants.RAW)) {
+                templateURL = getClass().getClassLoader()
+                        .getResource(IndexConstants.RAW_DEFAULT_TEMPLATE_FILE);
+            } else if (indexType.equals(IndexConstants.SERVICE_MAP)) {
+                templateURL = getClass().getClassLoader()
+                        .getResource(IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
+            } else if (templateFile != null) {
+                templateURL = new File(templateFile).toURI().toURL();
+            }
+            if (templateURL != null) {
+                return new ObjectMapper().readValue(templateURL, new TypeReference<Map<String, Object>>() {
+                });
+            } else {
+                return new HashMap<>();
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException("Index template is not valid.", ex);
+        }
     }
 
-    public IndexConfiguration build() {
-      return new IndexConfiguration(this);
-    }
-  }
+    public static class Builder {
+        private boolean isRaw = false;
+        private boolean isServiceMap = false;
+        private String indexAlias;
+        private String templateFile;
+        private int numShards;
+        private int numReplicas;
+        private String documentIdField;
+        private long bulkSize = DEFAULT_BULK_SIZE;
 
-  @SuppressWarnings("unchecked")
-  private IndexConfiguration(final Builder builder) {
-    final String indexType;
-    if (builder.isRaw && builder.isServiceMap) {
-      throw new IllegalStateException("trace_analytics_raw and trace_analytics_service_map cannot be both true.");
-    } else if (builder.isRaw) {
-      indexType = IndexConstants.RAW;
-    } else if (builder.isServiceMap) {
-      indexType = IndexConstants.SERVICE_MAP;
-    } else {
-      indexType = IndexConstants.CUSTOM;
-    }
-    this.indexType = indexType;
+        public Builder setIsRaw(final Boolean isRaw) {
+            checkNotNull(isRaw, "trace_analytics_raw cannot be null.");
+            this.isRaw = isRaw;
+            return this;
+        }
 
-    this.indexTemplate = readIndexTemplate(builder.templateFile, indexType);
+        public Builder setIsServiceMap(final Boolean isServiceMap) {
+            checkNotNull(isServiceMap, "trace_analytics_service_map cannot be null.");
+            this.isServiceMap = isServiceMap;
+            return this;
+        }
 
-    if(builder.numReplicas>0) {
-      indexTemplate.putIfAbsent(SETTINGS, new HashMap<>());
-      ((Map<String, Object>)indexTemplate.get(SETTINGS)).putIfAbsent(NUM_REPLICAS, builder.numReplicas);
-    }
+        public Builder withIndexAlias(final String indexAlias) {
+            checkArgument(indexAlias != null, "indexAlias cannot be null.");
+            checkArgument(!indexAlias.isEmpty(), "indexAlias cannot be empty");
+            this.indexAlias = indexAlias;
+            return this;
+        }
 
-    if(builder.numShards>0) {
-      indexTemplate.putIfAbsent(SETTINGS, new HashMap<>());
-      ((Map<String, Object>)indexTemplate.get(SETTINGS)).putIfAbsent(NUM_SHARDS, builder.numShards);
-    }
+        public Builder withTemplateFile(final String templateFile) {
+            checkArgument(templateFile != null, "templateFile cannot be null.");
+            this.templateFile = templateFile;
+            return this;
+        }
 
-    String indexAlias = builder.indexAlias;
-    if (IndexConstants.TYPE_TO_DEFAULT_ALIAS.containsKey(indexType)) {
-        indexAlias = IndexConstants.TYPE_TO_DEFAULT_ALIAS.get(indexType);
-    } else {
-      if (indexAlias == null) {
-        throw new IllegalStateException("Missing required properties:indexAlias");
-      }
-    }
-    this.indexAlias = indexAlias;
-    this.bulkSize = builder.bulkSize;
+        public Builder withDocumentIdField(final String documentIdField) {
+            checkNotNull(documentIdField, "documentId field cannot be null");
+            this.documentIdField = documentIdField;
+            return this;
+        }
 
-    String documentIdField = builder.documentIdField;
-    if (indexType.equals(IndexConstants.RAW)) {
-      documentIdField = "spanId";
-    } else if (indexType.equals(IndexConstants.SERVICE_MAP)) {
-      documentIdField = "hashId";
-    }
-    this.documentIdField = documentIdField;
-  }
+        public Builder withBulkSize(final long bulkSize) {
+            this.bulkSize = bulkSize;
+            return this;
+        }
 
-  public static IndexConfiguration readIndexConfig(final PluginSetting pluginSetting) {
-    IndexConfiguration.Builder builder = new IndexConfiguration.Builder();
-    builder.setIsRaw(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_RAW_FLAG, false));
-    builder.setIsServiceMap(pluginSetting.getBooleanOrDefault(TRACE_ANALYTICS_SERVICE_MAP_FLAG, false));
-    final String indexAlias = pluginSetting.getStringOrDefault(INDEX_ALIAS, null);
-    if (indexAlias != null) {
-      builder = builder.withIndexAlias(indexAlias);
-    }
-    final String templateFile = pluginSetting.getStringOrDefault(TEMPLATE_FILE, null);
-    if (templateFile != null) {
-      builder = builder.withTemplateFile(templateFile);
-    }
-    builder = builder.withNumShards(pluginSetting.getIntegerOrDefault(NUM_SHARDS, 0));
-    builder = builder.withNumShards(pluginSetting.getIntegerOrDefault(NUM_REPLICAS, 0));
-    final Long batchSize = pluginSetting.getLongOrDefault(BULK_SIZE, DEFAULT_BULK_SIZE);
-    builder = builder.withBulkSize(batchSize);
-    final String documentId = pluginSetting.getStringOrDefault(DOCUMENT_ID_FIELD, null);
-    if (documentId != null) {
-      builder = builder.withDocumentIdField(documentId);
-    }
-    return builder.build();
-  }
+        public Builder withNumShards(final int numShards) {
+            this.numShards = numShards;
+            return this;
+        }
 
-  /**
-   * This method is used in the creation of IndexConfiguration object. It takes in the template file path
-   * or index type and returns the index template read from the file or specific to index type or returns an
-   * empty map.
-   * @param templateFile
-   * @param indexType
-   * @return
-   */
-  private Map<String, Object> readIndexTemplate(final String templateFile, final String indexType) {
-    try {
-      URL templateURL = null;
-      if (indexType.equals(IndexConstants.RAW)) {
-        templateURL = getClass().getClassLoader()
-                .getResource(IndexConstants.RAW_DEFAULT_TEMPLATE_FILE);
-      } else if (indexType.equals(IndexConstants.SERVICE_MAP)) {
-        templateURL = getClass().getClassLoader()
-                .getResource(IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
-      } else if (templateFile != null) {
-        templateURL = new File(templateFile).toURI().toURL();
-      }
-      if(templateURL!=null) {
-        return new ObjectMapper().readValue(templateURL, new TypeReference<Map<String, Object>>() {
-        });
-      } else {
-        return new HashMap<>();
-      }
-    } catch (IOException ex) {
-      throw new IllegalStateException("Index template is not valid.", ex);
+        public Builder withNumReplicas(final int numReplicas) {
+            this.numReplicas = numReplicas;
+            return this;
+        }
+
+        public IndexConfiguration build() {
+            return new IndexConfiguration(this);
+        }
     }
-  }
 }

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfiguration.java
@@ -36,17 +36,15 @@ public class IndexConfiguration {
 
     @SuppressWarnings("unchecked")
     private IndexConfiguration(final Builder builder) {
-        final String indexType;
         if (builder.isRaw && builder.isServiceMap) {
             throw new IllegalStateException("trace_analytics_raw and trace_analytics_service_map cannot be both true.");
         } else if (builder.isRaw) {
-            indexType = IndexConstants.RAW;
+            this.indexType  = IndexConstants.RAW;
         } else if (builder.isServiceMap) {
-            indexType = IndexConstants.SERVICE_MAP;
+            this.indexType  = IndexConstants.SERVICE_MAP;
         } else {
-            indexType = IndexConstants.CUSTOM;
+            this.indexType  = IndexConstants.CUSTOM;
         }
-        this.indexType = indexType;
 
         this.indexTemplate = readIndexTemplate(builder.templateFile, indexType);
 

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexStateManagement.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexStateManagement.java
@@ -54,7 +54,7 @@ public class IndexStateManagement {
             final IndexConfiguration configuration, final String ismPolicyId, final String rolloverAlias) {
         configuration.getIndexTemplate().putIfAbsent("settings", new HashMap<>());
         // Attach policy_id and rollover_alias
-        ((Map<String, Object>)configuration.getIndexTemplate().get("settings")).put(IndexConstants.ISM_POLICY_ID_SETTING, ismPolicyId);
-        ((Map<String, Object>)configuration.getIndexTemplate().get("settings")).put(IndexConstants.ISM_ROLLOVER_ALIAS_SETTING, rolloverAlias);
+        ((Map<String, Object>) configuration.getIndexTemplate().get("settings")).put(IndexConstants.ISM_POLICY_ID_SETTING, ismPolicyId);
+        ((Map<String, Object>) configuration.getIndexTemplate().get("settings")).put(IndexConstants.ISM_ROLLOVER_ALIAS_SETTING, rolloverAlias);
     }
 }

--- a/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexStateManagement.java
+++ b/situp-plugins/elasticsearch/src/main/java/com/amazon/situp/plugins/sink/elasticsearch/IndexStateManagement.java
@@ -13,6 +13,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.HashMap;
 import java.util.Map;
 
 public class IndexStateManagement {
@@ -48,11 +49,12 @@ public class IndexStateManagement {
         }
     }
 
+    @SuppressWarnings("unchecked")
     public static void attachPolicy(
-            final Map<String, Object> settings, final String ismPolicyId, final String rolloverAlias) {
-        assert settings != null;
+            final IndexConfiguration configuration, final String ismPolicyId, final String rolloverAlias) {
+        configuration.getIndexTemplate().putIfAbsent("settings", new HashMap<>());
         // Attach policy_id and rollover_alias
-        settings.put(IndexConstants.ISM_POLICY_ID_SETTING, ismPolicyId);
-        settings.put(IndexConstants.ISM_ROLLOVER_ALIAS_SETTING, rolloverAlias);
+        ((Map<String, Object>)configuration.getIndexTemplate().get("settings")).put(IndexConstants.ISM_POLICY_ID_SETTING, ismPolicyId);
+        ((Map<String, Object>)configuration.getIndexTemplate().get("settings")).put(IndexConstants.ISM_ROLLOVER_ALIAS_SETTING, rolloverAlias);
     }
 }

--- a/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-service-map-index-template.json
+++ b/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-service-map-index-template.json
@@ -1,8 +1,4 @@
 {
-  "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 2
-  },
   "mappings": {
     "date_detection": false,
     "dynamic_templates": [

--- a/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json
+++ b/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json
@@ -1,8 +1,4 @@
 {
-  "settings": {
-    "number_of_shards": 1,
-    "number_of_replicas": 2
-  },
   "mappings": {
     "date_detection": false,
     "dynamic_templates": [

--- a/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfigurationTests.java
+++ b/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfigurationTests.java
@@ -44,12 +44,12 @@ public class IndexConfigurationTests {
 
   @Test
   public void testValidCustom() throws MalformedURLException {
-    final String fakeTemplateFilePath = Objects.requireNonNull(
+    final String defaultTemplateFilePath = Objects.requireNonNull(
             getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
     final String testIndexAlias = "foo";
     IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
             .withIndexAlias(testIndexAlias)
-            .withTemplateFile(fakeTemplateFilePath)
+            .withTemplateFile(defaultTemplateFilePath)
             .withBulkSize(10)
             .build();
 
@@ -118,12 +118,12 @@ public class IndexConfigurationTests {
 
   @Test
   public void testValidCustomWithTemplateFileAndShards() throws MalformedURLException {
-    final String fakeTemplateFilePath = Objects.requireNonNull(
+    final String defaultTemplateFilePath = Objects.requireNonNull(
             getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
     final String testIndexAlias = "foo";
     IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
             .withIndexAlias(testIndexAlias)
-            .withTemplateFile(fakeTemplateFilePath)
+            .withTemplateFile(defaultTemplateFilePath)
             .withBulkSize(10)
             .build();
 
@@ -190,13 +190,13 @@ public class IndexConfigurationTests {
 
   @Test
   public void testReadIndexConfigCustom() throws MalformedURLException {
-    final String fakeTemplateFilePath = Objects.requireNonNull(
+    final String defaultTemplateFilePath = Objects.requireNonNull(
             getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
     final String testIndexAlias = "foo";
     final long testBulkSize = 10L;
     final String testIdField = "someId";
     final PluginSetting pluginSetting = generatePluginSetting(
-            false, false, testIndexAlias, fakeTemplateFilePath, testBulkSize, testIdField);
+            false, false, testIndexAlias, defaultTemplateFilePath, testBulkSize, testIdField);
     final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
     assertEquals(CUSTOM, indexConfiguration.getIndexType());
     assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());

--- a/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfigurationTests.java
+++ b/situp-plugins/elasticsearch/src/test/java/com/amazon/situp/plugins/sink/elasticsearch/IndexConfigurationTests.java
@@ -8,6 +8,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.amazon.situp.plugins.sink.elasticsearch.IndexConstants.CUSTOM;
 import static com.amazon.situp.plugins.sink.elasticsearch.IndexConstants.RAW;
@@ -16,16 +17,20 @@ import static com.amazon.situp.plugins.sink.elasticsearch.IndexConstants.SERVICE
 import static com.amazon.situp.plugins.sink.elasticsearch.IndexConstants.SERVICE_MAP_DEFAULT_TEMPLATE_FILE;
 import static com.amazon.situp.plugins.sink.elasticsearch.IndexConstants.TYPE_TO_DEFAULT_ALIAS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("unchecked")
 public class IndexConfigurationTests {
+  private static final String DEFAULT_TEMPLATE_FILE = "test-template-withshards.json";
+
   @Test
   public void testRawAPMSpan() {
     final IndexConfiguration indexConfiguration = new IndexConfiguration.Builder().setIsRaw(true).build();
     final URL expTemplateURL = indexConfiguration.getClass().getClassLoader().getResource(RAW_DEFAULT_TEMPLATE_FILE);
     assertEquals(TYPE_TO_DEFAULT_ALIAS.get(RAW), indexConfiguration.getIndexAlias());
-    assertEquals(expTemplateURL, indexConfiguration.getTemplateURL());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
   }
 
   @Test
@@ -34,12 +39,13 @@ public class IndexConfigurationTests {
     final URL expTemplateURL = indexConfiguration
             .getClass().getClassLoader().getResource(SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
     assertEquals(TYPE_TO_DEFAULT_ALIAS.get(SERVICE_MAP), indexConfiguration.getIndexAlias());
-    assertEquals(expTemplateURL, indexConfiguration.getTemplateURL());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
   }
 
   @Test
   public void testValidCustom() throws MalformedURLException {
-    final String fakeTemplateFilePath = "src/resources/dummy.json";
+    final String fakeTemplateFilePath = Objects.requireNonNull(
+            getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
     final String testIndexAlias = "foo";
     IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
             .withIndexAlias(testIndexAlias)
@@ -49,8 +55,85 @@ public class IndexConfigurationTests {
 
     assertEquals(CUSTOM, indexConfiguration.getIndexType());
     assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
-    assertEquals(new File(fakeTemplateFilePath).toURI().toURL(), indexConfiguration.getTemplateURL());
     assertEquals(10, indexConfiguration.getBulkSize());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
+
+    indexConfiguration = new IndexConfiguration.Builder()
+            .setIsRaw(false)
+            .setIsServiceMap(false)
+            .withIndexAlias(testIndexAlias)
+            .withBulkSize(-1)
+            .build();
+    assertEquals(-1, indexConfiguration.getBulkSize());
+  }
+
+  @Test
+  public void testValidCustomWithNoTemplateFile() throws MalformedURLException {
+    final String testIndexAlias = "foo";
+    IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
+            .withIndexAlias(testIndexAlias)
+            .withBulkSize(10)
+            .build();
+
+    assertEquals(CUSTOM, indexConfiguration.getIndexType());
+    assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+    assertEquals(10, indexConfiguration.getBulkSize());
+    assertTrue(indexConfiguration.getIndexTemplate().isEmpty());
+
+    indexConfiguration = new IndexConfiguration.Builder()
+            .setIsRaw(false)
+            .setIsServiceMap(false)
+            .withIndexAlias(testIndexAlias)
+            .withBulkSize(-1)
+            .build();
+    assertEquals(-1, indexConfiguration.getBulkSize());
+  }
+
+  @Test
+  public void testValidCustomWithNoTemplateFileButWithShardsAndReplicas() throws MalformedURLException {
+    final String testIndexAlias = "foo";
+    IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
+            .withIndexAlias(testIndexAlias)
+            .withBulkSize(10)
+            .withNumShards(5)
+            .withNumReplicas(1)
+            .build();
+
+    assertEquals(CUSTOM, indexConfiguration.getIndexType());
+    assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+    assertEquals(10, indexConfiguration.getBulkSize());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
+    assertEquals(5, ((Map<String,Object>)indexConfiguration.getIndexTemplate().get(IndexConfiguration.SETTINGS)).get(IndexConfiguration.NUM_SHARDS));
+    assertEquals(1, ((Map<String,Object>)indexConfiguration.getIndexTemplate().get(IndexConfiguration.SETTINGS)).get(IndexConfiguration.NUM_REPLICAS));
+
+
+    indexConfiguration = new IndexConfiguration.Builder()
+            .setIsRaw(false)
+            .setIsServiceMap(false)
+            .withIndexAlias(testIndexAlias)
+            .withBulkSize(-1)
+            .build();
+    assertEquals(-1, indexConfiguration.getBulkSize());
+  }
+
+  @Test
+  public void testValidCustomWithTemplateFileAndShards() throws MalformedURLException {
+    final String fakeTemplateFilePath = Objects.requireNonNull(
+            getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
+    final String testIndexAlias = "foo";
+    IndexConfiguration indexConfiguration = new IndexConfiguration.Builder()
+            .withIndexAlias(testIndexAlias)
+            .withTemplateFile(fakeTemplateFilePath)
+            .withBulkSize(10)
+            .build();
+
+    assertEquals(CUSTOM, indexConfiguration.getIndexType());
+    assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
+    assertEquals(10, indexConfiguration.getBulkSize());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
+    assertEquals(100, ((Map<String,Object>)indexConfiguration.getIndexTemplate().get(IndexConfiguration.SETTINGS)).get(IndexConfiguration.NUM_SHARDS));
+    assertEquals(2, ((Map<String,Object>)indexConfiguration.getIndexTemplate().get(IndexConfiguration.SETTINGS)).get(IndexConfiguration.NUM_REPLICAS));
+
 
     indexConfiguration = new IndexConfiguration.Builder()
             .setIsRaw(false)
@@ -78,7 +161,7 @@ public class IndexConfigurationTests {
             .getClass().getClassLoader().getResource(RAW_DEFAULT_TEMPLATE_FILE);
     assertEquals(RAW, indexConfiguration.getIndexType());
     assertEquals(TYPE_TO_DEFAULT_ALIAS.get(RAW), indexConfiguration.getIndexAlias());
-    assertEquals(expTemplateFile, indexConfiguration.getTemplateURL());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
     assertEquals(5, indexConfiguration.getBulkSize());
     assertEquals("spanId", indexConfiguration.getDocumentIdField());
   }
@@ -92,7 +175,7 @@ public class IndexConfigurationTests {
             .getClass().getClassLoader().getResource(SERVICE_MAP_DEFAULT_TEMPLATE_FILE);
     assertEquals(SERVICE_MAP, indexConfiguration.getIndexType());
     assertEquals(TYPE_TO_DEFAULT_ALIAS.get(SERVICE_MAP), indexConfiguration.getIndexAlias());
-    assertEquals(expTemplateFile, indexConfiguration.getTemplateURL());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
     assertEquals(5, indexConfiguration.getBulkSize());
     assertEquals("hashId", indexConfiguration.getDocumentIdField());
   }
@@ -107,7 +190,8 @@ public class IndexConfigurationTests {
 
   @Test
   public void testReadIndexConfigCustom() throws MalformedURLException {
-    final String fakeTemplateFilePath = "src/resources/dummy.json";
+    final String fakeTemplateFilePath = Objects.requireNonNull(
+            getClass().getClassLoader().getResource(DEFAULT_TEMPLATE_FILE)).getFile();
     final String testIndexAlias = "foo";
     final long testBulkSize = 10L;
     final String testIdField = "someId";
@@ -116,7 +200,7 @@ public class IndexConfigurationTests {
     final IndexConfiguration indexConfiguration = IndexConfiguration.readIndexConfig(pluginSetting);
     assertEquals(CUSTOM, indexConfiguration.getIndexType());
     assertEquals(testIndexAlias, indexConfiguration.getIndexAlias());
-    assertEquals(new File(fakeTemplateFilePath).toURI().toURL(), indexConfiguration.getTemplateURL());
+    assertFalse(indexConfiguration.getIndexTemplate().isEmpty());
     assertEquals(testBulkSize, indexConfiguration.getBulkSize());
     assertEquals(testIdField, indexConfiguration.getDocumentIdField());
   }

--- a/situp-plugins/elasticsearch/src/test/resources/test-template-withshards.json
+++ b/situp-plugins/elasticsearch/src/test/resources/test-template-withshards.json
@@ -1,0 +1,29 @@
+{
+  "settings": {
+    "number_of_shards": 100,
+    "number_of_replicas": 2
+  },
+  "mappings": {
+    "date_detection": false,
+    "dynamic_templates": [
+      {
+        "strings_as_keyword": {
+          "mapping": {
+            "ignore_above": 1024,
+            "type": "keyword"
+          },
+          "match_mapping_type": "string"
+        }
+      }
+    ],
+    "_source": {
+      "enabled": false
+    },
+    "properties": {
+      "name": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Description of changes:*

* Added new configuration parameters for number_of_shards and number_of_replicas. This configuration is secondary to index template setting.

Note: Skipping the README, working on coming up with a similar template for all our plugins. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
