### PR TITLE
Use OpenTelemetry Collector 0.11.0 to make source TLS work.

### DIFF
--- a/examples/jaeger-hotrod/docker-compose.yml
+++ b/examples/jaeger-hotrod/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - opendistro-for-elasticsearch
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector:0.13.0
+    image: otel/opentelemetry-collector:0.11.0
     command: [ "--config=/etc/otel-collector-config.yml" ]
     working_dir: "/project"
     volumes:

--- a/examples/odfe-pipes-trace-app/docker-compose.yml
+++ b/examples/odfe-pipes-trace-app/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - opendistro-for-elasticsearch
   otel-collector:
     restart: unless-stopped
-    image: otel/opentelemetry-collector:0.13.0
+    image: otel/opentelemetry-collector:0.11.0
     command: ["--config=/etc/otel-collector-config.yml"]
     volumes:
       - ./opentelemetry-collector/otel-collector-config.yml:/etc/otel-collector-config.yml

--- a/examples/zipkin-sleuth-webmvc-example/docker-compose.yml
+++ b/examples/zipkin-sleuth-webmvc-example/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - opendistro-for-elasticsearch
   otel-collector:
     container_name: otel-collector
-    image: otel/opentelemetry-collector:0.13.0
+    image: otel/opentelemetry-collector:0.11.0
     command: [ "--config=/etc/otel-collector-config.yml" ]
     working_dir: "/project"
     volumes:


### PR DESCRIPTION

*Description of changes:*

For unknown reasons, the OTLP exporter with secure cert file doesnt work on versions after OpenTelemetry collector-0.11.0. So switching our examples to 0.11.0 while I investigate why latest versions fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
