### PR TITLE
Remove integration build that is affecting the app test.

### DIFF
--- a/situp-core/build.gradle
+++ b/situp-core/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'jacoco'
-    id 'com.bmuschko.docker-remote-api' version '6.6.1'
 }
 
 sourceSets {
@@ -10,8 +9,6 @@ sourceSets {
         }
     }
 }
-
-apply from: "integrationTest.gradle"
 
 dependencies {
     compile project(':situp-api')


### PR DESCRIPTION
Remove integration test as App test folks complained of it in their demo run.
```

sttachic@uac891278038952:~/Documents/avp3442_situp/simple-ingest-transformation-utility-pipeline/examples/jaeger-hotrod$ sudo docker-compose up -d --build
WARNING: The PWD variable is not set. Defaulting to a blank string.
Creating network "jaeger-hotrod_my_network" with the default driver
Pulling otel-collector (otel/opentelemetry-collector:0.11.0)...
0.11.0: Pulling from otel/opentelemetry-collector
aec9c7fd0082: Pull complete
73bb920a22a2: Pull complete
710006bb55f4: Pull complete
Digest: sha256:4905ac9b2acffcd3181151c8e1545864ca783f8e5761b4b8505361039a6276f3
Status: Downloaded newer image for otel/opentelemetry-collector:0.11.0
Building situp
Step 1/10 : FROM gradle:jdk14 AS builder
jdk14: Pulling from library/gradle
171857c49d0f: Pull complete
419640447d26: Pull complete
61e52f862619: Pull complete
dd4d4e9526b1: Pull complete
7bdbab1a3d9e: Pull complete
7d84ae7bfa87: Pull complete
55515e3d0de1: Pull complete
34dc550380e3: Pull complete
Digest: sha256:f3083db83022eb3246a53e74ba6288e78d1707fe5fc378d1295458d9a9175912
Status: Downloaded newer image for gradle:jdk14
 ---> 5af4d25725b2
Step 2/10 : COPY . /home/gradle/src
 ---> e248f95bf964
Step 3/10 : WORKDIR /home/gradle/src/situp-core
 ---> Running in 86a3f8c2f505
Removing intermediate container 86a3f8c2f505
 ---> e00c610d52c9
Step 4/10 : RUN gradle jar --daemon
 ---> Running in 5cd5e1d5a284
Welcome to Gradle 6.7!
Here are the highlights of this release:
 - File system watching is ready for production use
 - Declare the version of Java your build requires
 - Java 15 support
For more details see https://docs.gradle.org/6.7/release-notes.html
Starting a Gradle Daemon (subsequent builds will be faster)
FAILURE: Build failed with an exception.
* Where:
Build file '/home/gradle/src/situp-core/build.gradle' line: 3
* What went wrong:
Plugin [id: 'com.bmuschko.docker-remote-api', version: '6.6.1'] was not found in any of the following sources:
- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (could not resolve plugin artifact 'com.bmuschko.docker-remote-api:com.bmuschko.docker-remote-api.gradle.plugin:6.6.1')
  Searched in the following repositories:
    Gradle Central Plugin Repository
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 27s
ERROR: Service 'situp' failed to build : The command '/bin/sh -c gradle jar --daemon' returned a non-zero code: 1

```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
