### PR TITLE
Add mac os for tar distribution

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -23,30 +23,43 @@ docker run --name situp-test --expose 21890 --read-only -v /home/ec2-user/situp-
 **Supported Platform**
 
 * Linux
+* Mac OS
 
 ### Running a tar build
 
 To build a tar, check out the corresponding branch for the version and follow below steps
 
 1. Building a tar depends on the platform on which it will be executed/run
-2. From the root project, run  `./gradlew clean :release:<platform>:<platform>WithJDKDistTar -Prelease`
-3. Successful build should generate the tar in `release/<platform>/build/distributions/` directory
-4. Generated tar includes a script file which can be used to execute the situp using 
+2. From the root project, run  `./gradlew clean :release:<platform>:<platform>Tar -Prelease`
+3. Successful build should generate two tars in `release/<platform>/build/distributions/` directory
+4. Generated tars includes a script file which can be used to execute the situp using 
 ```
 tar -xzf situp-<platform>-jdk-<VERSION>.tar.gz
 ./situp-<platform>-jdk-<VERSION>/situp-tar-install.sh <CONFIG FILE LOCATION>
 ```
 
 ### Example
- For linux platform, above steps will be as below
+* For linux platform, above steps will be as below
  ```
-./gradlew clean :release:linux:linuxWithJDKDistTar -Prelease
+./gradlew clean :release:linux:linuxTar -Prelease
 
 cd release/linux/build/distributions/
 
 tar -xzf situp-linux_x86_64-jdk-<VERSION>.tar.gz
 
 ./situp-linux_x86_64-jdk-<VERSION>/situp-tar-install.sh <CONFIG FILE LOCATION>
+
+```
+
+* For mac OS, above steps will be as below
+ ```
+./gradlew clean :release:macOS:macOSTar -Prelease
+
+cd release/macOS/build/distributions/
+
+tar -xzf situp-macOS_x64-jdk-<VERSION>.tar.gz
+
+./situp-macOS_x64-jdk-<VERSION>/situp-tar-install.sh <CONFIG FILE LOCATION>
 
 ```
    

--- a/release/build-resources.gradle
+++ b/release/build-resources.gradle
@@ -1,6 +1,7 @@
 //preferably try to main the alphabetical order
 ext {
     jdkSources = [
-            linux_x86_64: 'https://download.java.net/openjdk/jdk14/ri/openjdk-14+36_linux-x64_bin.tar.gz'
+            linux_x86_64: 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz',
+            macOS_x64: 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz'
     ]
 }

--- a/release/linux/build.gradle
+++ b/release/linux/build.gradle
@@ -43,7 +43,7 @@ task linuxTar {
     dependsOn linuxWithJDKDistTar
 }
 
-task macOSZip {
+task linuxZip {
     dependsOn linuxDistZip
     dependsOn linuxWithJDKDistZip
 }

--- a/release/linux/situp-tar-install-with-jdk.sh
+++ b/release/linux/situp-tar-install-with-jdk.sh
@@ -25,7 +25,7 @@ OPENJDK=$(ls -1 $SITUP_HOME/openjdk/ 2>/dev/null)
 
 if [[ -z "$EXECUTABLE_JAR" ]]
 then
-  echo "Expected jar file missing from directory $SITUP_HOME/bin; Please consider running the script from the un-tar directory"
+  echo "Jar file is missing from directory $SITUP_HOME/bin"
   exit 1
 fi
 

--- a/release/linux/situp-tar-install-with-jdk.sh
+++ b/release/linux/situp-tar-install-with-jdk.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+if [[ $# -eq 0 ]]
+  then
+    echo "Path to the configuration file is required"
+    exit 1
+fi
+
+CONFIG_FILE_LOCATION=$1
+SITUP_HOME=$(dirname $(realpath $0))
+EXECUTABLE_JAR=$(ls -1 $SITUP_HOME/bin/*.jar 2>/dev/null)
+OPENJDK=$(ls -1 $SITUP_HOME/openjdk/ 2>/dev/null)
+
+if [[ -z "$EXECUTABLE_JAR" ]]
+then
+  echo "Expected jar file missing from directory $SITUP_HOME/bin; Please consider running the script from the un-tar directory"
+  exit 1
+fi
+
+export JAVA_HOME=$SITUP_HOME/openjdk/$OPENJDK
+echo "JAVA_HOME is set to $JAVA_HOME"
+export PATH=$JAVA_HOME/bin:$PATH
+
+SITUP_JAVA_OPTS="-Dlog4j.configurationFile=$SITUP_HOME/config/log4j.properties"
+java $JAVA_OPTS $SITUP_JAVA_OPTS -jar $EXECUTABLE_JAR $CONFIG_FILE_LOCATION

--- a/release/linux/situp-tar-install.sh
+++ b/release/linux/situp-tar-install.sh
@@ -26,7 +26,7 @@ EXECUTABLE_JAR=$(ls -1 $SITUP_HOME/bin/*.jar 2>/dev/null)
 
 if [[ -z "$EXECUTABLE_JAR" ]]
 then
-  echo "Expected jar file missing from directory $SITUP_HOME/bin"
+  echo "Jar file is missing from directory $SITUP_HOME/bin"
   exit 1
 fi
 

--- a/release/macOS/build.gradle
+++ b/release/macOS/build.gradle
@@ -2,9 +2,9 @@ plugins {
     id "de.undercouch.download" version "4.1.1"
     id "distribution"
 }
-def platform = "linux_x86_64"
+def platform = "macOS_x64"
 distributions {
-    linux {
+    macOS {
         distributionBaseName = "${project.rootProject.name}-${platform}"
         contents {
             with archiveToTar("${platform}")
@@ -14,7 +14,7 @@ distributions {
             }
         }
     }
-    linuxWithJDK {
+    macOSWithJDK {
         distributionBaseName = "${project.rootProject.name}-${platform}-jdk"
         contents {
             with archiveToTar("${platform}")
@@ -38,15 +38,16 @@ task downloadJDK {
         }
     }
 }
-task linuxTar {
-    dependsOn linuxDistTar
-    dependsOn linuxWithJDKDistTar
+
+task macOSTar {
+    dependsOn macOSDistTar
+    dependsOn macOSWithJDKDistTar
 }
 
 task macOSZip {
-    dependsOn linuxDistZip
-    dependsOn linuxWithJDKDistZip
+    dependsOn macOSDistZip
+    dependsOn macOSWithJDKDistZip
 }
 
-linuxWithJDKDistTar.dependsOn downloadJDK
-linuxWithJDKDistZip.dependsOn downloadJDK
+macOSWithJDKDistTar.dependsOn downloadJDK
+macOSWithJDKDistZip.dependsOn downloadJDK

--- a/release/macOS/situp-tar-install-with-jdk.sh
+++ b/release/macOS/situp-tar-install-with-jdk.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License").
+# You may not use this file except in compliance with the License.
+# A copy of the License is located at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+if [[ $# -eq 0 ]]
+  then
+    echo "Path to the configuration file is required"
+    exit 1
+fi
+
+CONFIG_FILE_LOCATION=$1
+SITUP_HOME=$(cd "$(dirname "$0")"; pwd)
+EXECUTABLE_JAR=$(ls -1 $SITUP_HOME/bin/*.jar 2>/dev/null)
+OPENJDK=$(ls -1 $SITUP_HOME/openjdk/ 2>/dev/null)
+
+if [[ -z "$EXECUTABLE_JAR" ]]
+then
+  echo "Expected jar file missing from directory $SITUP_HOME/bin"
+  exit 1
+fi
+
+export JAVA_HOME=$SITUP_HOME/openjdk/$OPENJDK/Contents/Home
+export PATH=$JAVA_HOME/bin:$PATH
+SITUP_JAVA_OPTS="-Dlog4j.configurationFile=$SITUP_HOME/config/log4j.properties"
+$JAVA_HOME/bin/java $JAVA_OPTS $SITUP_JAVA_OPTS -jar $EXECUTABLE_JAR $CONFIG_FILE_LOCATION

--- a/release/macOS/situp-tar-install-with-jdk.sh
+++ b/release/macOS/situp-tar-install-with-jdk.sh
@@ -26,7 +26,7 @@ OPENJDK=$(ls -1 $SITUP_HOME/openjdk/ 2>/dev/null)
 
 if [[ -z "$EXECUTABLE_JAR" ]]
 then
-  echo "Expected jar file missing from directory $SITUP_HOME/bin"
+  echo "Jar file is missing from directory $SITUP_HOME/bin"
   exit 1
 fi
 

--- a/release/macOS/situp-tar-install.sh
+++ b/release/macOS/situp-tar-install.sh
@@ -12,6 +12,7 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
+
 if [[ $# -eq 0 ]]
   then
     echo "Path to the configuration file is required"
@@ -21,7 +22,7 @@ fi
 CONFIG_FILE_LOCATION=$1
 MIN_REQ_JAVA_VERSION=1.8
 MIN_REQ_OPENJDK_VERSION=8
-SITUP_HOME=$(dirname $(realpath $0))
+SITUP_HOME=$(cd "$(dirname "$0")"; pwd)
 EXECUTABLE_JAR=$(ls -1 $SITUP_HOME/bin/*.jar 2>/dev/null)
 
 if [[ -z "$EXECUTABLE_JAR" ]]
@@ -30,7 +31,6 @@ then
   exit 1
 fi
 
-#check if java is installed
 if type -p java; then
     _java=java
 elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then

--- a/release/macOS/situp-tar-install.sh
+++ b/release/macOS/situp-tar-install.sh
@@ -27,7 +27,7 @@ EXECUTABLE_JAR=$(ls -1 $SITUP_HOME/bin/*.jar 2>/dev/null)
 
 if [[ -z "$EXECUTABLE_JAR" ]]
 then
-  echo "Expected jar file missing from directory $SITUP_HOME/bin"
+  echo "Jar file is missing from directory $SITUP_HOME/bin"
   exit 1
 fi
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,7 @@ if(startParameter.getProjectProperties().containsKey("release")){
     include 'release'
     include 'release:docker'
     include 'release:linux'
+    include 'release:macOS'
 }
 include 'situp-api'
 include 'situp-plugins'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add macOS module for mac OS compatible tar generation

### Testing

* With JDK - *Notice it is using openjdk 15*
```
f45c89b92765:Temp byadav$ ./situp-macOS_x64-jdk-0.1-beta/situp-tar-install.sh situp.yml
openjdk 15.0.1 2020-10-20
OpenJDK Runtime Environment (build 15.0.1+9-18)
OpenJDK 64-Bit Server VM (build 15.0.1+9-18, mixed mode, sharing)
0    [main] INFO  com.amazon.situp.Situp  – Using situp.yml configuration file
462  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building pipeline [entry-pipeline] from provided configuration
462  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building [otel_trace_source] as source component for the pipeline [entry-pipeline]
650  [main] INFO  org.reflections.Reflections  – Reflections took 159 ms to scan 1 urls, producing 19 keys and 44 values 
697  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building buffer for the pipeline [entry-pipeline]
701  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building processors for t
```

Without JDK
```
f45c89b92765:Temp byadav$ ./situp-macOS_x64-0.1-beta/situp-tar-install.sh situp.yml 
/usr/bin/java
Found java version  of 1.8
java version "1.8.0_231"
Java(TM) SE Runtime Environment (build 1.8.0_231-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.231-b11, mixed mode)
0    [main] INFO  com.amazon.situp.Situp  – Using situp.yml configuration file
396  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building pipeline [entry-pipeline] from provided configuration
397  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building [otel_trace_source] as source component for the pipeline [entry-pipeline]
665  [main] INFO  org.reflections.Reflections  – Reflections took 202 ms to scan 1 urls, producing 19 keys and 44 values 
720  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building buffer for the pipeline [entry-pipeline]
721  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building processors for the pipeline [entry-pipeline]
723  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building sinks for the pipeline [entry-pipeline]
725  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building [pipeline] as sink component
726  [main] INFO  com.amazon.situp.parser.PipelineParser  – Building [pipeline] as sink component

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
