### PR TITLE
Add pipeline level configuration to PluginSettings

### DIFF
--- a/situp-api/src/main/java/com/amazon/situp/model/configuration/PluginSetting.java
+++ b/situp-api/src/main/java/com/amazon/situp/model/configuration/PluginSetting.java
@@ -6,6 +6,8 @@ public class PluginSetting {
 
     private final String name;
     private final Map<String, Object> settings;
+    private int processWorkers;
+    private String pipelineName;
 
     public PluginSetting(final String name, final Map<String, Object> settings) {
         this.name = name;
@@ -18,6 +20,42 @@ public class PluginSetting {
 
     public Map<String, Object> getSettings() {
         return settings;
+    }
+
+    /**
+     * Returns the number of process workers the pipeline is using; This is only required for special plugin use-cases
+     * where plugin implementation depends on the number of process workers. For example, Trace analytics service map
+     * processor plugin uses memory mapped databases and it requires to know the number of workers that operate on it
+     * concurrently.
+     * @return Number of process workers
+     */
+    public int getNumberOfProcessWorkers() {
+        return processWorkers;
+    }
+
+    /**
+     * This method is solely for pipeline execution to set the process workers and it is recommended not to be used.
+     * @param processWorkers number of process workers
+     */
+    public void setProcessWorkers(final int processWorkers) {
+        this.processWorkers = processWorkers;
+    }
+
+    /**
+     * Returns the name of the associated pipeline.
+     * @return name of the associated pipeline
+     */
+    public String getPipelineName() {
+        return this.pipelineName;
+    }
+
+    /**
+     * This method is solely for pipeline execution to set the associated pipeline name and it is recommended not to be
+     * used.
+     * @param pipelineName associated pipeline name
+     */
+    public void setPipelineName(final String pipelineName) {
+        this.pipelineName = pipelineName;
     }
 
     /**

--- a/situp-api/src/test/java/com/amazon/situp/model/configuration/PluginSettingsTest.java
+++ b/situp-api/src/test/java/com/amazon/situp/model/configuration/PluginSettingsTest.java
@@ -14,6 +14,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PluginSettingsTest {
     private static final String TEST_PLUGIN_NAME = "test";
+    private static final String TEST_PIPELINE = "test-pipeline";
+    private static final int TEST_WORKERS = 1;
     private static final Map<String, Object> TEST_SETTINGS = ImmutableMap.of("attribute1", 1000,
             "attribute2", 2000);
 
@@ -22,6 +24,8 @@ public class PluginSettingsTest {
     @Before
     public void setup() {
         pluginSetting = new PluginSetting(TEST_PLUGIN_NAME, TEST_SETTINGS);
+        pluginSetting.setPipelineName(TEST_PIPELINE);
+        pluginSetting.setProcessWorkers(TEST_WORKERS);
     }
 
     @Test
@@ -33,6 +37,8 @@ public class PluginSettingsTest {
     public void testPluginSettingsNameAndAttribute() {
         assertThat(pluginSetting.getName(), is(TEST_PLUGIN_NAME));
         assertThat(pluginSetting.getSettings(), is(TEST_SETTINGS));
+        assertThat(pluginSetting.getPipelineName(), is(TEST_PIPELINE));
+        assertThat(pluginSetting.getNumberOfProcessWorkers(), is(TEST_WORKERS));
         assertThat(pluginSetting.getAttributeFromSettings("attribute1"), is(1000));
         assertThat(pluginSetting.getAttributeOrDefault("not-present", 500), is(500));
 

--- a/situp-core/src/main/java/com/amazon/situp/parser/PipelineParser.java
+++ b/situp-core/src/main/java/com/amazon/situp/parser/PipelineParser.java
@@ -83,7 +83,7 @@ public class PipelineParser {
             final Source source = pipelineSource.orElseGet(() -> SourceFactory.newSource(sourceSetting));
 
             LOG.info("Building buffer for the pipeline [{}]", pipelineName);
-            final Buffer buffer = getBufferOrDefault(pipelineConfiguration.getBufferPluginSetting(),pipelineName);
+            final Buffer buffer = getBufferOrDefault(pipelineConfiguration.getBufferPluginSetting(), pipelineName);
 
             LOG.info("Building processors for the pipeline [{}]", pipelineName);
             final List<Processor> processors = pipelineConfiguration.getProcessorPluginSettings().stream()
@@ -116,11 +116,6 @@ public class PipelineParser {
 
     private int getDelayOrDefault(final Integer readBatchDelay) {
         return readBatchDelay == null ? DEFAULT_READ_BATCH_DELAY : readBatchDelay;
-    }
-
-    private void updatePluginSettings(final PluginSetting pluginSetting, final String pipelineName, final int workers) {
-        pluginSetting.setPipelineName(pipelineName);
-        pluginSetting.setProcessWorkers(workers);
     }
 
     /**

--- a/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
+++ b/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
@@ -4,7 +4,6 @@ import com.amazon.situp.model.configuration.PluginSetting;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -47,7 +46,7 @@ public class PipelineConfiguration {
     }
 
     private PluginSetting getBufferFromConfiguration(final Map.Entry<String, Map<String, Object>> bufferConfiguration) {
-        if(bufferConfiguration==null) {
+        if (bufferConfiguration == null) {
             return null;
         }
         return getPluginSettingFromConfiguration(bufferConfiguration);

--- a/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
+++ b/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
@@ -13,8 +13,6 @@ import java.util.stream.Collectors;
 import static java.lang.String.format;
 
 public class PipelineConfiguration {
-    private static final String SOURCE_COMPONENT = "source";
-    private static final String BUFFER_COMPONENT = "buffer";
     private static final String WORKERS_COMPONENT = "workers";
     private static final String DELAY_COMPONENT = "delay";
 

--- a/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
+++ b/situp-core/src/main/java/com/amazon/situp/parser/model/PipelineConfiguration.java
@@ -38,6 +38,49 @@ public class PipelineConfiguration {
         this.readBatchDelay = getReadBatchDelayFromConfiguration(delay);
     }
 
+    public PluginSetting getSourcePluginSetting() {
+        return sourcePluginSetting;
+    }
+
+    public PluginSetting getBufferPluginSetting() {
+        return bufferPluginSetting;
+    }
+
+    public List<PluginSetting> getProcessorPluginSettings() {
+        return processorPluginSettings;
+    }
+
+    public List<PluginSetting> getSinkPluginSettings() {
+        return sinkPluginSettings;
+    }
+
+    public Integer getWorkers() {
+        return workers;
+    }
+
+    public Integer getReadBatchDelay() {
+        return readBatchDelay;
+    }
+
+    public void updateCommonPipelineConfiguration(final String pipelineName, final int processWorkers) {
+        updatePluginSetting(sourcePluginSetting, pipelineName, processWorkers);
+        updatePluginSetting(bufferPluginSetting, pipelineName, processWorkers);
+        processorPluginSettings.forEach(processorPluginSettings ->
+                updatePluginSetting(processorPluginSettings, pipelineName, processWorkers));
+        sinkPluginSettings.forEach(sinkPluginSettings ->
+                updatePluginSetting(sinkPluginSettings, pipelineName, processWorkers));
+    }
+
+    private void updatePluginSetting(
+            final PluginSetting pluginSetting,
+            final String pipelineName,
+            final int processWorkers) {
+        if (pluginSetting != null) {
+            pluginSetting.setPipelineName(pipelineName);
+            pluginSetting.setProcessWorkers(processWorkers);
+        }
+    }
+
     private PluginSetting getSourceFromConfiguration(final Map.Entry<String, Map<String, Object>> sourceConfiguration) {
         if (sourceConfiguration == null) {
             throw new IllegalArgumentException("Invalid configuration, source is a required component");
@@ -69,7 +112,6 @@ public class PipelineConfiguration {
     }
 
 
-
     private static PluginSetting getPluginSettingFromConfiguration(
             final Map.Entry<String, Map<String, Object>> configuration) {
         return new PluginSetting(configuration.getKey(), configuration.getValue());
@@ -89,29 +131,5 @@ public class PipelineConfiguration {
                     component, configuration));
         }
         return configuration;
-    }
-
-    public PluginSetting getSourcePluginSetting() {
-        return sourcePluginSetting;
-    }
-
-    public PluginSetting getBufferPluginSetting() {
-        return bufferPluginSetting;
-    }
-
-    public List<PluginSetting> getProcessorPluginSettings() {
-        return processorPluginSettings;
-    }
-
-    public List<PluginSetting> getSinkPluginSettings() {
-        return sinkPluginSettings;
-    }
-
-    public Integer getWorkers() {
-        return workers;
-    }
-
-    public Integer getReadBatchDelay() {
-        return readBatchDelay;
     }
 }

--- a/situp-core/src/main/java/com/amazon/situp/pipeline/Pipeline.java
+++ b/situp-core/src/main/java/com/amazon/situp/pipeline/Pipeline.java
@@ -57,7 +57,7 @@ public class Pipeline {
             @Nonnull final List<Sink> sinks,
             final int processorThreads,
             final int readBatchTimeoutInMillis) {
-        this(name, source, new BlockingBuffer(), EMPTY_PROCESSOR_LIST, sinks, processorThreads, readBatchTimeoutInMillis);
+        this(name, source, new BlockingBuffer(name), EMPTY_PROCESSOR_LIST, sinks, processorThreads, readBatchTimeoutInMillis);
     }
 
     /**

--- a/situp-core/src/test/java/com/amazon/situp/pipeline/PipelineTests.java
+++ b/situp-core/src/test/java/com/amazon/situp/pipeline/PipelineTests.java
@@ -83,7 +83,7 @@ public class PipelineTests {
             throw new RuntimeException("Processor is expected to fail");
         };
         try {
-            testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(),
+            testPipeline = new Pipeline(TEST_PIPELINE_NAME, testSource, new BlockingBuffer(TEST_PIPELINE_NAME),
                     Collections.singletonList(testProcessor), Collections.singletonList(testSink), TEST_PROCESSOR_THREADS,
                     TEST_READ_BATCH_TIMEOUT);
             testPipeline.execute();

--- a/situp-plugins/common/src/test/java/com/amazon/situp/plugins/buffer/BlockingBufferTest.java
+++ b/situp-plugins/common/src/test/java/com/amazon/situp/plugins/buffer/BlockingBufferTest.java
@@ -17,6 +17,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class BlockingBufferTest {
     private static final String ATTRIBUTE_BATCH_SIZE = "batch_size";
     private static final String ATTRIBUTE_BUFFER_SIZE = "buffer_size";
+    private static final String TEST_PIPELINE_NAME = "test-pipeline";
     private static final int TEST_BATCH_SIZE = 3;
     private static final int TEST_BUFFER_SIZE = 13;
     private static final int TEST_WRITE_TIMEOUT = 1_00;
@@ -31,20 +32,23 @@ public class BlockingBufferTest {
 
     @Test
     public void testCreationUsingDefaults() {
-        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE);
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
     }
 
     @Test(expected = NullPointerException.class)
     public void testInsertNull() throws TimeoutException {
-        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE);
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
         blockingBuffer.write(null, TEST_WRITE_TIMEOUT);
     }
 
     @Test(expected = TimeoutException.class)
     public void testNoEmptySpace() throws TimeoutException {
-        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(1, TEST_BATCH_SIZE);
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(1, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
         blockingBuffer.write(new Record<>("FILL_THE_BUFFER"), TEST_WRITE_TIMEOUT);
         blockingBuffer.write(new Record<>("TIMEOUT"), TEST_WRITE_TIMEOUT);
@@ -52,7 +56,8 @@ public class BlockingBufferTest {
 
     @Test
     public void testReadEmptyBuffer() {
-        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE);
+        final BlockingBuffer<Record<String>> blockingBuffer = new BlockingBuffer<>(TEST_BUFFER_SIZE, TEST_BATCH_SIZE,
+                TEST_PIPELINE_NAME);
         assertThat(blockingBuffer, notNullValue());
         Collection<Record<String>> records = blockingBuffer.read(TEST_BATCH_READ_TIMEOUT);
         assertThat(records.size(), is(0));
@@ -89,6 +94,8 @@ public class BlockingBufferTest {
         final Map<String, Object> settings = new HashMap<>();
         settings.put(ATTRIBUTE_BUFFER_SIZE, TEST_BUFFER_SIZE);
         settings.put(ATTRIBUTE_BATCH_SIZE, TEST_BATCH_SIZE);
-        return new PluginSetting(pluginName, settings);
+        final PluginSetting testSettings =  new PluginSetting(pluginName, settings);
+        testSettings.setPipelineName(TEST_PIPELINE_NAME);
+        return testSettings;
     }
 }

--- a/situp-plugins/common/src/test/java/com/amazon/situp/plugins/buffer/BufferFactoryTests.java
+++ b/situp-plugins/common/src/test/java/com/amazon/situp/plugins/buffer/BufferFactoryTests.java
@@ -14,7 +14,6 @@ import static org.junit.Assert.assertThrows;
 
 @SuppressWarnings("rawtypes")
 public class BufferFactoryTests {
-
     /**
      * Tests if BufferFactory is able to retrieve default Source plugins by name
      */
@@ -22,7 +21,7 @@ public class BufferFactoryTests {
     public void testNewBufferClassByNameThatExists() {
         final PluginSetting boundedBlocking = new PluginSetting("bounded_blocking", new HashMap<>());
         final Buffer actualBuffer = BufferFactory.newBuffer(boundedBlocking);
-        final Buffer expectedBuffer = new BlockingBuffer();
+        final Buffer expectedBuffer = new BlockingBuffer("test-pipeline");
         assertNotNull(actualBuffer);
         assertEquals(expectedBuffer.getClass().getSimpleName(), actualBuffer.getClass().getSimpleName());
     }

--- a/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java
+++ b/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java
@@ -25,19 +25,17 @@ public class MapDbProcessorState<V> implements ProcessorState<byte[], V> {
     }
 
     private static final SignedByteArraySerializer SIGNED_BYTE_ARRAY_SERIALIZER = new SignedByteArraySerializer();
-    //TODO: Take this concurrency as an argument or from the pipeline configuration
-    private static final int DEFAULT_CONCURRENCY = 16;
 
     private final BTreeMap<byte[], V> map;
 
-    public MapDbProcessorState(final File dbPath, final String dbName) {
+    public MapDbProcessorState(final File dbPath, final String dbName, final int concurrencyScale) {
         map =
                 (BTreeMap<byte[], V>) DBMaker.fileDB(new File(String.join("/", dbPath.getPath(), dbName)))
                         .fileDeleteAfterClose()
                         .fileMmapEnable() //MapDB uses the (slower) Random Access Files by default
                         .fileMmapPreclearDisable()
                         .executorEnable()
-                        .concurrencyScale(DEFAULT_CONCURRENCY)
+                        .concurrencyScale(concurrencyScale)
                         .make()
                         .treeMap(dbName)
                         .counterEnable() //Treemap doesnt keep:q size counter by default

--- a/situp-plugins/mapdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/MapDbProcessorStateTest.java
+++ b/situp-plugins/mapdb-processor-state/src/test/java/com/amazon/situp/plugins/processor/state/MapDbProcessorStateTest.java
@@ -17,7 +17,7 @@ public class MapDbProcessorStateTest extends ProcessorStateTest {
 
     @Override
     public void setProcessorState() throws Exception {
-        this.processorState = new MapDbProcessorState<>(temporaryFolder.newFolder(), "testDb");
+        this.processorState = new MapDbProcessorState<>(temporaryFolder.newFolder(), "testDb", 16);
     }
 
     @Test

--- a/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
+++ b/situp-plugins/service-map-stateful/src/test/java/com/amazon/situp/plugins/processor/ServiceMapStatefulProcessorTest.java
@@ -62,8 +62,8 @@ public class ServiceMapStatefulProcessorTest {
         Mockito.when(clock.instant()).thenReturn(Instant.now());
         ExecutorService threadpool = Executors.newCachedThreadPool();
         final File path = new File(ServiceMapProcessorConfig.DEFAULT_LMDB_PATH);
-        final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, clock);
-        final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, clock);
+        final ServiceMapStatefulProcessor serviceMapStateful1 = new ServiceMapStatefulProcessor(100, path, clock, 16);
+        final ServiceMapStatefulProcessor serviceMapStateful2 = new ServiceMapStatefulProcessor(100, path, clock, 16);
 
         final byte[] rootSpanId1 = ServiceMapTestUtils.getRandomBytes(8);
         final byte[] rootSpanId2 = ServiceMapTestUtils.getRandomBytes(8);


### PR DESCRIPTION
*Issue #, if available:*
#119 

*Description of changes:*

1. Add pipeline level configuration like pipeline name and process workers to Plugin settings. Adding it to PluginSettings will make it available to plugins and facilitates use-cases where plugins need information about number of process workers the pipeline is running.
2. Update ServiceMapProcessor and related State class to use the process workers from PluginSettings. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
