### PR TITLE
Add traceGroup to the raw-index.

### DIFF
--- a/situp-core/src/integrationTest/java/com/amazon/situp/integration/EndToEndRawSpanTest.java
+++ b/situp-core/src/integrationTest/java/com/amazon/situp/integration/EndToEndRawSpanTest.java
@@ -177,6 +177,9 @@ public class EndToEndRawSpanTest {
         esDocSource.put("status.code", span.getStatus().getCodeValue());
         esDocSource.put("status.message", span.getStatus().getMessage());
         esDocSource.put("serviceName", serviceName);
+        if (span.getParentSpanId().isEmpty()) {
+            esDocSource.put("traceGroup", span.getName());
+        }
         return esDocSource;
     }
 

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/processor/oteltrace/model/OTelProtoHelper.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/processor/oteltrace/model/OTelProtoHelper.java
@@ -96,13 +96,30 @@ public final class OTelProtoHelper {
         return event.getAttributesList().stream().collect(Collectors.toMap(i -> REPLACE_DOT_WITH_AT.apply(i.getKey()), i -> convertAnyValue(i.getValue())));
     }
 
+    /**
+     * Trace group represent root span i.e the span which triggers the trace event with the microservice architecture. This field is not part of the OpenTelemetry Spec.
+     * This field is something specific to Trace Analytics feature that Kibana will be supporting. This field is derived from the opentelemetry spec and set as below,
+     * <p>
+     * if (this.parentSpanId.isEmpty()) {
+     * traceGroup = this.name;
+     * }
+     * <p>
+     * Note: The reason this method is part of the helper class is because the trace group definition will be expanded in the future when we support Links in Kibana Trace Analytics.
+     */
+    public static String getTraceGroup(final Span span) {
+        if (span.getParentSpanId().isEmpty()) {
+            return span.getName();
+        }
+        return null;
+    }
+
 
     public static Map<String, Object> getInstrumentationLibraryAttributes(final InstrumentationLibrary instrumentationLibrary) {
         final Map<String, Object> instrumentationAttr = new HashMap<>();
-        if(!instrumentationLibrary.getName().isEmpty()){
+        if (!instrumentationLibrary.getName().isEmpty()) {
             instrumentationAttr.put(INSTRUMENTATION_LIBRARY_NAME, instrumentationLibrary.getName());
         }
-        if(!instrumentationLibrary.getVersion().isEmpty()){
+        if (!instrumentationLibrary.getVersion().isEmpty()) {
             instrumentationAttr.put(INSTRUMENTATION_LIBRARY_VERSION, instrumentationLibrary.getVersion());
         }
         return instrumentationAttr;

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/processor/oteltrace/model/RawSpan.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/processor/oteltrace/model/RawSpan.java
@@ -83,6 +83,17 @@ public final class RawSpan {
      */
     private final int droppedLinksCount;
 
+    /**
+     * Trace group represent root span i.e the span which triggers the trace event with the microservice architecture. This field is not part of the OpenTelemetry Spec.
+     * This field is something specific to Trace Analytics feature that Kibana will be supporting. This field is derived from the opentelemetry spec and set as below,
+     * <p>
+     * if (this.parentSpanId.isEmpty()) {
+     * traceGroup = this.name;
+     * }
+     */
+    private final String traceGroup;
+
+
     public String getTraceId() {
         return traceId;
     }
@@ -143,11 +154,6 @@ public final class RawSpan {
         return droppedLinksCount;
     }
 
-    @JsonAnyGetter
-    public Map<String, Object> getAttributes() {
-        return attributes;
-    }
-
     RawSpan(RawSpanBuilder builder) {
         this.traceId = builder.traceId;
         this.spanId = builder.spanId;
@@ -165,6 +171,16 @@ public final class RawSpan {
         this.droppedAttributesCount = builder.droppedAttributesCount;
         this.droppedEventsCount = builder.droppedEventsCount;
         this.droppedLinksCount = builder.droppedLinksCount;
+        this.traceGroup = builder.traceGroup;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public String getTraceGroup() {
+        return traceGroup;
     }
 
     public String toJson() throws JsonProcessingException {

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/processor/oteltrace/model/RawSpanBuilder.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/processor/oteltrace/model/RawSpanBuilder.java
@@ -29,6 +29,7 @@ public final class RawSpanBuilder {
     int droppedAttributesCount;
     int droppedEventsCount;
     int droppedLinksCount;
+    String traceGroup;
 
 
     public RawSpanBuilder() {
@@ -99,6 +100,10 @@ public final class RawSpanBuilder {
         return this;
     }
 
+    private RawSpanBuilder setTraceGroup(final String traceGroup) {
+        this.traceGroup = traceGroup;
+        return this;
+    }
 
 
     private RawSpanBuilder setSpanAttributes(final Map<String, Object> spanAttributes,
@@ -148,6 +153,7 @@ public final class RawSpanBuilder {
                 .setLinks(span.getLinksList().stream().map(RawLink::buildRawLink).collect(Collectors.toList()))
                 .setDroppedAttributesCount(span.getDroppedAttributesCount())
                 .setDroppedEventsCount(span.getDroppedEventsCount())
-                .setDroppedLinksCount(span.getDroppedLinksCount());
+                .setDroppedLinksCount(span.getDroppedLinksCount())
+                .setTraceGroup(OTelProtoHelper.getTraceGroup(span));
     }
 }

--- a/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/processor/oteltrace/model/OTelProtoHelperTest.java
+++ b/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/processor/oteltrace/model/OTelProtoHelperTest.java
@@ -2,6 +2,7 @@ package com.amazon.situp.plugins.processor.oteltrace.model;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
 import io.opentelemetry.proto.common.v1.AnyValue;
 import io.opentelemetry.proto.common.v1.ArrayValue;
 import io.opentelemetry.proto.common.v1.InstrumentationLibrary;
@@ -12,6 +13,7 @@ import io.opentelemetry.proto.trace.v1.Span;
 import io.opentelemetry.proto.trace.v1.Status;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -170,11 +172,19 @@ public class OTelProtoHelperTest {
         final Span emptyTimeSpan = Span.newBuilder().build();
 
         final String startTime = OTelProtoHelper.getStartTimeISO8601(startTimeUnixNano);
-        assertThat(Instant.parse(startTime).getEpochSecond()*NANO_MULTIPLIER + Instant.parse(startTime).getNano() == startTimeUnixNano.getStartTimeUnixNano()).isTrue();
+        assertThat(Instant.parse(startTime).getEpochSecond() * NANO_MULTIPLIER + Instant.parse(startTime).getNano() == startTimeUnixNano.getStartTimeUnixNano()).isTrue();
         final String endTime = OTelProtoHelper.getEndTimeISO8601(endTimeUnixNano);
-        assertThat(Instant.parse(endTime).getEpochSecond()*NANO_MULTIPLIER + Instant.parse(endTime).getNano() == endTimeUnixNano.getEndTimeUnixNano()).isTrue();
+        assertThat(Instant.parse(endTime).getEpochSecond() * NANO_MULTIPLIER + Instant.parse(endTime).getNano() == endTimeUnixNano.getEndTimeUnixNano()).isTrue();
         final String emptyTime = OTelProtoHelper.getStartTimeISO8601(endTimeUnixNano);
-        assertThat(Instant.parse(emptyTime).getEpochSecond()*NANO_MULTIPLIER + Instant.parse(emptyTime).getNano() == emptyTimeSpan.getStartTimeUnixNano()).isTrue();
+        assertThat(Instant.parse(emptyTime).getEpochSecond() * NANO_MULTIPLIER + Instant.parse(emptyTime).getNano() == emptyTimeSpan.getStartTimeUnixNano()).isTrue();
 
+    }
+
+    @Test
+    public void testTraceGroup() {
+        final Span span1 = Span.newBuilder().setParentSpanId(ByteString.copyFrom("PArentIdExists", StandardCharsets.UTF_8)).build();
+        assertThat(OTelProtoHelper.getTraceGroup(span1)).isNull();
+        final Span span2 = Span.newBuilder().setName("TraceGroup").build();
+        assertThat(OTelProtoHelper.getTraceGroup(span2)).isEqualToIgnoringCase("TraceGroup");
     }
 }

--- a/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json
+++ b/situp-plugins/elasticsearch/src/main/resources/otel-v1-apm-span-index-template.json
@@ -39,6 +39,10 @@
         "ignore_above": 1024,
         "type": "keyword"
       },
+      "traceGroup": {
+        "ignore_above": 1024,
+        "type": "keyword"
+      },
       "kind": {
         "ignore_above": 128,
         "type": "keyword"


### PR DESCRIPTION
*Description of changes:*

Kibana team requested to add the traceGroup as a field, this would benefit the trace analytics UI. Trace Group is concept introduced by Trace Analytics UI, we call the name of the span which has no parentSpan as traceGroup.

* Added `traceGroup` to raw span
* Added field to index template and updated the E2E


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
