### PR TITLE
Fixing docker-compose 'volume name is too short' bug in zipkin and ja…

### DIFF
--- a/examples/jaeger-hotrod/docker-compose.yml
+++ b/examples/jaeger-hotrod/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     command: [ "--config=/etc/otel-collector-config.yml" ]
     working_dir: "/project"
     volumes:
-      - ${PWD}:/project
+      - ${PWD}/:/project
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
       - ../demo/demo-situp.crt:/etc/demo-situp.crt
     ports:

--- a/examples/zipkin-sleuth-webmvc-example/docker-compose.yml
+++ b/examples/zipkin-sleuth-webmvc-example/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     command: [ "--config=/etc/otel-collector-config.yml" ]
     working_dir: "/project"
     volumes:
-      - ${PWD}:/project
+      - ${PWD}/:/project
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml
     ports:
       - "9411"   # Zipkin receiver


### PR DESCRIPTION
…eger examples.

*Description of changes:*
Ran into issues while trying to start the zipkin and jaeger examples, specifically:
```
Successfully built 90a48fb316c4
Successfully tagged jaeger-hotrod_kibana:latest
Creating jaeger-agent ...
Creating odfe-kibana  ...
Creating jaeger-agent       ... done
Creating odfe-kibana        ... done

Creating node-0.example.com ... done
Creating situp                          ... done
Creating jaeger-hotrod_jaeger-hot-rod_1 ... done

ERROR: for otel-collector  Cannot create container for service otel-collector: create .: volume name is too short, names should be at least two alphanumeric characters
ERROR: Encountered errors while bringing up the project.
```
and
```
Successfully built 90a48fb316c4
Successfully tagged zipkin-sleuth-webmvc-example_kibana:latest
Creating node-0.example.com ... done
Creating odfe-kibana        ... done
Creating zipkin             ... done
Creating situp              ...
Creating backend            ...
Creating situp              ... done
Creating backend            ... done
ERROR: for otel-collector  Cannot create container for service otel-collector: create .: volume name is too short, names should be at least two alphanumeric characters
Creating frontend           ... done

ERROR: for otel-collector  Cannot create container for service otel-collector: create .: volume name is too short, names should be at least two alphanumeric characters
ERROR: Encountered errors while bringing up the project.
```

The command run was `sudo docker-compose up -d --build`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
