### PR TITLE
Enable Protoreflection for App Test

### DIFF
--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
@@ -36,6 +36,7 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                             .builder()
                             .addService(new OTelTraceGrpcService(oTelTraceSourceConfig.getRequestTimeoutInMillis(), buffer))
                             .addService(ProtoReflectionService.newInstance())
+                            .enableUnframedRequests(true)
                             .useClientTimeoutHeader(false)
                             .build());
             sb.requestTimeoutMillis(oTelTraceSourceConfig.getRequestTimeoutInMillis());

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
@@ -9,6 +9,7 @@ import com.amazon.situp.model.source.Source;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                     GrpcService
                             .builder()
                             .addService(new OTelTraceGrpcService(oTelTraceSourceConfig.getRequestTimeoutInMillis(), buffer))
-                            .enableUnframedRequests(true) // This will enable non-Grpc requests
+                            .addService(ProtoReflectionService.newInstance())
                             .useClientTimeoutHeader(false)
                             .build());
             sb.requestTimeoutMillis(oTelTraceSourceConfig.getRequestTimeoutInMillis());


### PR DESCRIPTION
*Description of changes:*

Enable ProtoReflection to allow grpcurl for AppTest.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
