### PR TITLE
ENH: set min and max heap size of situp in examples

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -8,4 +8,4 @@ EXPOSE 21890
 WORKDIR /app
 RUN apk --no-cache add curl
 COPY --from=builder /home/gradle/src/situp-core/build/libs/situp*.jar /app/situp.jar
-CMD ["java", "-jar", "situp.jar", "/app/transformation-instance.yml"]
+CMD ["java", "-Xms128m", "-Xmx128m", "-jar", "situp.jar", "/app/transformation-instance.yml"]

--- a/examples/odfe-pipes-trace-app/docker-compose.yml
+++ b/examples/odfe-pipes-trace-app/docker-compose.yml
@@ -12,8 +12,11 @@ services:
       - ../situp-wait-for-odfe-and-start.sh:/app/situp-wait-for-odfe-and-start.sh
       - ../trace_analytics_no_ssl.yml:/app/transformation-instance.yml
       - ../demo/root-ca.pem:/app/root-ca.pem
+    expose:
+      - '8849'
     ports:
-      - "21890:21890"
+      - '8849:8849'
+      - '21890:21890'
     networks:
       - my_network
     depends_on:

--- a/examples/odfe-pipes-trace-app/docker-compose.yml
+++ b/examples/odfe-pipes-trace-app/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ../trace_analytics_no_ssl.yml:/app/transformation-instance.yml
       - ../demo/root-ca.pem:/app/root-ca.pem
     ports:
-      - '21890:21890'
+      - "21890:21890"
     networks:
       - my_network
     depends_on:

--- a/examples/odfe-pipes-trace-app/docker-compose.yml
+++ b/examples/odfe-pipes-trace-app/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - INVENTORY=python-services
       - PAYMENT=python-services
       - AUTH=python-services
-      - SLEEP_TIME_IN_SECONDS=5
+      - SLEEP_TIME_IN_SECONDS=0.01
       - WAIT_HOSTS=python-services:8085 # auth
       - WAIT_AFTER_HOSTS=20
     depends_on:

--- a/examples/odfe-pipes-trace-app/docker-compose.yml
+++ b/examples/odfe-pipes-trace-app/docker-compose.yml
@@ -115,7 +115,7 @@ services:
       - INVENTORY=python-services
       - PAYMENT=python-services
       - AUTH=python-services
-      - SLEEP_TIME_IN_SECONDS=0.01
+      - SLEEP_TIME_IN_SECONDS=1
       - WAIT_HOSTS=python-services:8085 # auth
       - WAIT_AFTER_HOSTS=20
     depends_on:

--- a/examples/odfe-pipes-trace-app/docker-compose.yml
+++ b/examples/odfe-pipes-trace-app/docker-compose.yml
@@ -12,10 +12,7 @@ services:
       - ../situp-wait-for-odfe-and-start.sh:/app/situp-wait-for-odfe-and-start.sh
       - ../trace_analytics_no_ssl.yml:/app/transformation-instance.yml
       - ../demo/root-ca.pem:/app/root-ca.pem
-    expose:
-      - '8849'
     ports:
-      - '8849:8849'
       - '21890:21890'
     networks:
       - my_network

--- a/examples/situp-wait-for-odfe-and-start.sh
+++ b/examples/situp-wait-for-odfe-and-start.sh
@@ -5,13 +5,4 @@ until [[ $(curl --write-out %{http_code} --output /dev/null --silent --head --fa
   sleep 1
 done
 
-java \
--Xms128m -Xmx128m \
--Dcom.sun.management.jmxremote=true \
--Dcom.sun.management.jmxremote.port=8849 \
--Dcom.sun.management.jmxremote.authenticate=false \
--Dcom.sun.management.jmxremote.ssl=false \
--Dcom.sun.management.jmxremote.local.only=false \
--Dcom.sun.management.jmxremote.rmi.port=8849 \
--Djava.rmi.server.hostname=localhost \
--jar situp.jar /app/transformation-instance.yml
+java -Xms128m -Xmx128m -jar situp.jar /app/transformation-instance.yml

--- a/examples/situp-wait-for-odfe-and-start.sh
+++ b/examples/situp-wait-for-odfe-and-start.sh
@@ -5,4 +5,13 @@ until [[ $(curl --write-out %{http_code} --output /dev/null --silent --head --fa
   sleep 1
 done
 
-java -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=8849 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=8849 -Djava.rmi.server.hostname=localhost -jar situp.jar /app/transformation-instance.yml
+java \
+-Xms128m -Xmx128m \
+-Dcom.sun.management.jmxremote=true \
+-Dcom.sun.management.jmxremote.port=8849 \
+-Dcom.sun.management.jmxremote.authenticate=false \
+-Dcom.sun.management.jmxremote.ssl=false \
+-Dcom.sun.management.jmxremote.local.only=false \
+-Dcom.sun.management.jmxremote.rmi.port=8849 \
+-Djava.rmi.server.hostname=localhost \
+-jar situp.jar /app/transformation-instance.yml

--- a/examples/situp-wait-for-odfe-and-start.sh
+++ b/examples/situp-wait-for-odfe-and-start.sh
@@ -5,4 +5,4 @@ until [[ $(curl --write-out %{http_code} --output /dev/null --silent --head --fa
   sleep 1
 done
 
-exec java -jar situp.jar /app/transformation-instance.yml
+java -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.port=8849 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.local.only=false -Dcom.sun.management.jmxremote.rmi.port=8849 -Djava.rmi.server.hostname=localhost -jar situp.jar /app/transformation-instance.yml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed xms and xmx to 128m.
- Set sleep time to 1s

Tested on `jaeger-hotrod` and `odfe-pipes-trace-app`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
