### PR TITLE
Upgrade proto to 0.10.0

### DIFF
--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -12,5 +12,5 @@ ext.versionMap = [
         slf4j_api              : '1.7.30',
         slf4j_log4j12          : '1.7.30',
         validation_api         : '2.0.1.Final',
-        opentelemetry_proto    : '0.9.1'
+        opentelemetry_proto    : '0.10.0'
 ]

--- a/examples/odfe-pipes-trace-app/python-services/requirements.txt
+++ b/examples/odfe-pipes-trace-app/python-services/requirements.txt
@@ -1,7 +1,7 @@
 mysql-connector==2.2.9
-opentelemetry-exporter-otlp==0.12b0
-opentelemetry-instrumentation-flask==0.12b0
-opentelemetry-instrumentation-mysql==0.12b0
-opentelemetry-instrumentation-requests==0.12b0
-opentelemetry-sdk==0.12b0
+opentelemetry-exporter-otlp==0.14b0
+opentelemetry-instrumentation-flask==0.14b0
+opentelemetry-instrumentation-mysql==0.14b0
+opentelemetry-instrumentation-requests==0.14b0
+opentelemetry-sdk==0.14b0
 protobuf==3.12.2

--- a/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/processor/oteltrace/model/OTelProtoHelperTest.java
+++ b/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/processor/oteltrace/model/OTelProtoHelperTest.java
@@ -144,9 +144,9 @@ public class OTelProtoHelperTest {
 
     @Test
     public void testStatusAttributes(){
-        final Status st1 = Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_ABORTED).setMessage("Some message").build();
+        final Status st1 = Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_ERROR).setMessage("Some message").build();
         final Status st2 = Status.newBuilder().setMessage("error message").build();
-        final Status st3 = Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_ALREADY_EXISTS).build();
+        final Status st3 = Status.newBuilder().setCode(Status.StatusCode.STATUS_CODE_UNSET).build();
         final Status st4 = Status.newBuilder().build();
 
         assertThat(OTelProtoHelper.getSpanStatusAttributes(st1).size()==2).isTrue();

--- a/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/processor/oteltrace/model/RawBuilderTest.java
+++ b/situp-plugins/apmtracesource/src/test/java/com/amazon/situp/plugins/processor/oteltrace/model/RawBuilderTest.java
@@ -30,7 +30,7 @@ public class RawBuilderTest {
                 .setKind(Span.SpanKind.SPAN_KIND_CONSUMER)
                 .setStartTimeUnixNano(651242400000000321L)
                 .setEndTimeUnixNano(651242400000000321L+3000)
-                .setStatus(Status.newBuilder().setCodeValue(Status.StatusCode.STATUS_CODE_ABORTED_VALUE).setMessage("status-description").build())
+                .setStatus(Status.newBuilder().setCodeValue(Status.StatusCode.STATUS_CODE_UNSET_VALUE).setMessage("status-description").build())
                 .addAttributes(KeyValue.newBuilder()
                         .setKey("some-key")
                         .build()
@@ -51,7 +51,7 @@ public class RawBuilderTest {
         assertThat(rawSpan.getStartTime().equals(OTelProtoHelper.getStartTimeISO8601(span))).isTrue();
         assertThat(rawSpan.getEndTime().equals(OTelProtoHelper.getEndTimeISO8601(span))).isTrue();
         assertThat(rawSpan.getAttributes().get(OTelProtoHelper.STATUS_MESSAGE)).isEqualTo("status-description");
-        assertThat(rawSpan.getAttributes().get(OTelProtoHelper.STATUS_CODE)).isEqualTo(10);
+        assertThat(rawSpan.getAttributes().get(OTelProtoHelper.STATUS_CODE)).isEqualTo(0);
         assertThat(rawSpan.getAttributes().get(OTelProtoHelper.SPAN_ATTRIBUTES_REPLACE_DOT_WITH_AT.apply("some-key")).equals("")).isTrue();
         assertThat(rawSpan.getDroppedAttributesCount()).isEqualTo(1);
         assertThat(rawSpan.getDroppedLinksCount()).isEqualTo(0);


### PR DESCRIPTION
*Issue #, if available:*
#151 

*Description of changes:*
- Upgraded proto dependency to v.10.0 and fixes the relevant test cases
- Upgrade on opentelemetry-python sdk to the latest working version 0.14b0

Tested with sample app, adot and jaeger. Status code now only 3 values

Note: For opentelemetry-python 0.15b0, I met with this bug https://github.com/open-telemetry/opentelemetry-python/pull/1101#discussion_r515398299

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
