### PR TITLE
Refactor archives build.gradle

### DIFF
--- a/release/archives/build.gradle
+++ b/release/archives/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "de.undercouch.download" version "4.1.1" apply false
     id "jp.classmethod.aws.s3" version "0.41" apply false
 }
+import jp.classmethod.aws.gradle.s3.CreateBucketTask
 
 subprojects {
     apply plugin: 'de.undercouch.download'
@@ -15,6 +16,44 @@ subprojects {
         implementation "javax.xml.bind:jaxb-api:2.3.1"
     }
 
+    ext {
+        archiveToTar = this.&archiveToTar
+        awsS3Bucket = project.hasProperty("bucket") ? project.getProperty("bucket") : awsResources.get('default_bucket')
+    }
+
+    def platform = platforms.get(it.name)
+    def distName = it.name
+    def distTar = "${distName}DistTar"
+    def distZip = "${distName}DistZip"
+    def distNameWithJDK = it.name + "WithJDK"
+    def distWithJDKTar = "${distNameWithJDK}DistTar"
+    def distWithJDKZip = "${distNameWithJDK}DistZip"
+
+    distributions {
+        "${distName}" {
+            distributionBaseName = "${project.rootProject.name}-${platform}"
+            contents {
+                with archiveToTar()
+                into('') {
+                    from("situp-tar-install.sh")
+                    fileMode 0755
+                }
+            }
+        }
+        "${distNameWithJDK}" {
+            distributionBaseName = "${project.rootProject.name}-${platform}-jdk"
+            contents {
+                with archiveToTar()
+                into('openjdk') {
+                    from tarTree("${buildDir}/${platform}/openjdk/openjdk.tar.gz")
+                }
+                into('') {
+                    from("situp-tar-install-with-jdk.sh").rename("situp-tar-install-with-jdk.sh", "situp-tar-install.sh")
+                    fileMode 0755
+                }
+            }
+        }
+    }
     tasks.withType(Tar) {
         dependsOn ':release:releasePrerequisites'
         compression = Compression.GZIP
@@ -25,14 +64,45 @@ subprojects {
         dependsOn ':release:releasePrerequisites'
     }
 
-    ext {
-        archiveToTar = this.&archiveToTar
-        awsS3Bucket = project.hasProperty("bucket") ? project.getProperty("bucket") : awsResources.get('default_bucket')
+    task downloadJDK {
+        doLast {
+            download {
+                src jdkSources[platform]
+                dest "${buildDir}/${platform}/openjdk/openjdk.tar.gz"
+                overwrite false
+            }
+        }
+    }
+
+    tasks.create("${it.name}Tar") {
+        dependsOn "${distTar}"
+        dependsOn "${distWithJDKTar}"
+    }
+
+    tasks.create("${it.name}Zip") {
+        dependsOn "${distZip}"
+        dependsOn "${distWithJDKZip}"
     }
 
     aws {
         profileName = project.hasProperty("profile") ? project.getProperty("profile") : awsResources.get('default_profile')
         region = project.hasProperty("region") ? project.getProperty("region") : awsResources.get('default_region')
+    }
+
+    task createBucket(type: CreateBucketTask) {
+        bucketName awsS3Bucket
+        ifNotExists true
+    }
+    afterEvaluate {
+        tasks.getByName("${distNameWithJDK}DistTar").dependsOn(downloadJDK)
+        tasks.getByName("${distNameWithJDK}DistZip").dependsOn(downloadJDK)
+
+        tasks.create("uploadToS3") {
+            dependsOn uploadTarToS3
+            dependsOn uploadTarWithJDKToS3
+            dependsOn uploadZipToS3
+            dependsOn uploadZipWithJDKToS3
+        }
     }
 }
 
@@ -63,6 +133,16 @@ task uploadArchives {
     subprojects.each { dependsOn ':release:archives:' + it.name + ':uploadToS3' }
 }
 
-task buildArchives {
+task buildTar {
     subprojects.each { dependsOn ':release:archives:' + it.name + ':' + it.name + 'Tar' }
+
+}
+
+task buildZip {
+    subprojects.each { dependsOn ':release:archives:' + it.name + ':' + it.name + 'Zip' }
+}
+
+task buildArchives {
+    dependsOn buildTar
+    dependsOn buildZip
 }

--- a/release/archives/linux/build.gradle
+++ b/release/archives/linux/build.gradle
@@ -1,55 +1,6 @@
 import com.amazonaws.services.s3.model.ObjectMetadata
 import jp.classmethod.aws.gradle.s3.AmazonS3FileUploadTask
-import jp.classmethod.aws.gradle.s3.CreateBucketTask
 
-def platform = "linux_x86_64"
-distributions {
-    linux {
-        distributionBaseName = "${project.rootProject.name}-${platform}"
-        contents {
-            with archiveToTar()
-            into('') {
-                from("situp-tar-install.sh")
-                fileMode 0755
-            }
-        }
-    }
-    linuxWithJDK {
-        distributionBaseName = "${project.rootProject.name}-${platform}-jdk"
-        contents {
-            with archiveToTar()
-            into('openjdk') {
-                from tarTree("${buildDir}/${platform}/openjdk/openjdk.tar.gz")
-            }
-            into('') {
-                from("situp-tar-install-with-jdk.sh").rename("situp-tar-install-with-jdk.sh", "situp-tar-install.sh")
-                fileMode 0755
-            }
-        }
-    }
-}
-
-task downloadJDK {
-    doLast {
-        download {
-            src jdkSources[platform]
-            dest "${buildDir}/${platform}/openjdk/openjdk.tar.gz"
-            overwrite false
-        }
-    }
-}
-task linuxTar {
-    dependsOn linuxDistTar
-    dependsOn linuxWithJDKDistTar
-}
-task linuxZip {
-    dependsOn linuxDistZip
-    dependsOn linuxWithJDKDistZip
-}
-task createBucket(type: CreateBucketTask) {
-    bucketName awsS3Bucket
-    ifNotExists true
-}
 task uploadTarToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket) {
     dependsOn linuxDistTar
     file file(linuxDistTar.archiveFile.get().asFile.absolutePath)
@@ -70,10 +21,24 @@ task uploadTarWithJDKToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket
     m.setCacheControl("no-cache, no-store")
     objectMetadata = m
 }
-task uploadToS3 {
-    dependsOn uploadTarToS3
-    dependsOn uploadTarWithJDKToS3
+task uploadZipToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket) {
+    dependsOn linuxDistZip
+    file file(linuxDistZip.archiveFile.get().asFile.absolutePath)
+    bucketName awsS3Bucket
+    key linuxDistZip.archiveName
+
+    def m = new ObjectMetadata()
+    m.setCacheControl("no-cache, no-store")
+    objectMetadata = m
 }
 
-linuxWithJDKDistTar.dependsOn downloadJDK
-linuxWithJDKDistZip.dependsOn downloadJDK
+task uploadZipWithJDKToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket) {
+    dependsOn linuxWithJDKDistZip
+    file file(linuxWithJDKDistZip.archiveFile.get().asFile.absolutePath)
+    bucketName awsS3Bucket
+    key linuxWithJDKDistZip.archiveName
+
+    def m = new ObjectMetadata()
+    m.setCacheControl("no-cache, no-store")
+    objectMetadata = m
+}

--- a/release/archives/macOS/build.gradle
+++ b/release/archives/macOS/build.gradle
@@ -1,47 +1,5 @@
 import com.amazonaws.services.s3.model.ObjectMetadata
 import jp.classmethod.aws.gradle.s3.AmazonS3FileUploadTask
-import jp.classmethod.aws.gradle.s3.CreateBucketTask
-
-def platform = "macOS_x64"
-distributions {
-    macOS {
-        distributionBaseName = "${project.rootProject.name}-${platform}"
-        contents {
-            with archiveToTar()
-            into('') {
-                from("situp-tar-install.sh")
-                fileMode 0755
-            }
-        }
-    }
-    macOSWithJDK {
-        distributionBaseName = "${project.rootProject.name}-${platform}-jdk"
-        contents {
-            with archiveToTar()
-            into('openjdk') {
-                from tarTree("${buildDir}/${platform}/openjdk/openjdk.tar.gz")
-            }
-            into('') {
-                from("situp-tar-install-with-jdk.sh").rename("situp-tar-install-with-jdk.sh", "situp-tar-install.sh")
-                fileMode 0755
-            }
-        }
-    }
-}
-
-task downloadJDK {
-    doLast {
-        download {
-            src jdkSources[platform]
-            dest "${buildDir}/${platform}/openjdk/openjdk.tar.gz"
-            overwrite false
-        }
-    }
-}
-task createBucket(type: CreateBucketTask) {
-    bucketName awsS3Bucket
-    ifNotExists true
-}
 
 task uploadTarToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket) {
     dependsOn macOSDistTar
@@ -63,20 +21,23 @@ task uploadTarWithJDKToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket
     m.setCacheControl("no-cache, no-store")
     objectMetadata = m
 }
-task uploadToS3 {
-    dependsOn uploadTarToS3
-    dependsOn uploadTarWithJDKToS3
-}
-
-task macOSTar {
-    dependsOn macOSDistTar
-    dependsOn macOSWithJDKDistTar
-}
-
-task macOSZip {
+task uploadZipToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket) {
     dependsOn macOSDistZip
-    dependsOn macOSWithJDKDistZip
-}
+    file file(macOSDistZip.archiveFile.get().asFile.absolutePath)
+    bucketName awsS3Bucket
+    key macOSDistZip.archiveName
 
-macOSWithJDKDistTar.dependsOn downloadJDK
-macOSWithJDKDistZip.dependsOn downloadJDK
+    def m = new ObjectMetadata()
+    m.setCacheControl("no-cache, no-store")
+    objectMetadata = m
+}
+task uploadZipWithJDKToS3 (type: AmazonS3FileUploadTask, dependsOn: createBucket) {
+    dependsOn macOSWithJDKDistZip
+    file file(macOSWithJDKDistZip.archiveFile.get().asFile.absolutePath)
+    bucketName awsS3Bucket
+    key macOSWithJDKDistZip.archiveName
+
+    def m = new ObjectMetadata()
+    m.setCacheControl("no-cache, no-store")
+    objectMetadata = m
+}

--- a/release/build-resources.gradle
+++ b/release/build-resources.gradle
@@ -1,5 +1,9 @@
 //preferably try to main the alphabetical order
 ext {
+    platforms = [
+            linux: 'linux_x86_64',
+            macOS: 'macOS_x64'
+    ]
     jdkSources = [
             linux_x86_64: 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz',
             macOS_x64: 'https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz'
@@ -7,6 +11,6 @@ ext {
     awsResources = [
             default_region: 'us-east-1',
             default_profile: 'default',
-            default_bucket: 'odfe-situp'
+            default_bucket: 'artifacts.odfesitup.amazon.com'
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Move common tasks to subprojects closure 
* Add zip's - _when we add windows, we will disable tar for windows_
* Update upload tasks

Next: Find a way to move the uploadArchives to parent project from subprojects.

### Testing

All archives and their directories
```
byadav$ ls
situp-linux_x86_64-0.1-beta		situp-linux_x86_64-jdk-0.1-beta		situp-macOS_x64-0.1-beta		situp-macOS_x64-jdk-0.1-beta
situp-linux_x86_64-0.1-beta.tar.gz	situp-linux_x86_64-jdk-0.1-beta.tar.gz	situp-macOS_x64-0.1-beta.tar.gz		situp-macOS_x64-jdk-0.1-beta.tar.gz
situp-linux_x86_64-0.1-beta.zip		situp-linux_x86_64-jdk-0.1-beta.zip	situp-macOS_x64-0.1-beta.zip		situp-macOS_x64-jdk-0.1-beta.zip
f45c89b92765:todelete byadav$ cd situp-linux_x86_64-0.1-beta
f45c89b92765:situp-linux_x86_64-0.1-beta byadav$ cd ..
f45c89b92765:todelete byadav$ ls situp-linux_x86_64-0.1-beta
LICENSE			NOTICE			bin			config			examples		situp-tar-install.sh
f45c89b92765:todelete byadav$ less situp-linux_x86_64-0.1-beta/situp-tar-install.sh 
f45c89b92765:todelete byadav$ ls situp-linux_x86_64-jdk-0.1-beta
LICENSE			NOTICE			bin			config			examples		openjdk			situp-tar-install.sh
f45c89b92765:todelete byadav$ less situp-linux_x86_64-jdk-0.1-beta/situp-tar-install.sh 
f45c89b92765:todelete byadav$ ls situp-macOS_x64-0.1-beta
LICENSE			NOTICE			bin			config			examples		situp-tar-install.sh
f45c89b92765:todelete byadav$ less situp-macOS_x64-0.1-beta/situp-tar-install.sh 
f45c89b92765:todelete byadav$ ls situp-macOS_x64-jdk-0.1-beta
LICENSE			NOTICE			bin			config			examples		openjdk			situp-tar-install.sh
```

Build output

```
f45c89b92765:simple-ingest-transformation-utility-pipeline byadav$ ./gradlew clean :release:archives:buildZip -Prelease --console=plain
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.5
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-14.0.2.jdk/Contents/Home
  Random Testing Seed   : 16B07CBE84323D63
  In FIPS 140 mode      : false
=======================================
> Task :release:clean UP-TO-DATE
> Task :research:clean UP-TO-DATE
> Task :situp-api:clean
> Task :situp-benchmarks:clean UP-TO-DATE
> Task :situp-core:clean
> Task :situp-plugins:clean
> Task :release:archives:clean UP-TO-DATE
> Task :release:docker:clean UP-TO-DATE
> Task :research:zipkin-elastic-to-otel:clean UP-TO-DATE
> Task :situp-benchmarks:lmdb-benchmarks:clean UP-TO-DATE
> Task :situp-benchmarks:mapdb-benchmarks:clean UP-TO-DATE
> Task :situp-benchmarks:service-map-stateful-benchmarks:clean UP-TO-DATE
> Task :situp-plugins:apmtracesource:clean
> Task :situp-plugins:common:clean
> Task :situp-plugins:elasticsearch:clean
> Task :situp-plugins:lmdb-processor-state:clean
> Task :situp-plugins:mapdb-processor-state:clean
> Task :situp-plugins:service-map-stateful:clean
> Task :release:archives:linux:clean UP-TO-DATE
> Task :release:archives:macOS:clean
> Task :release:benchmarkTests UP-TO-DATE
> Task :situp-api:compileJava
> Task :situp-api:processResources NO-SOURCE
> Task :situp-api:classes
> Task :situp-api:jar
> Task :situp-plugins:common:compileJava
> Task :situp-plugins:common:processResources NO-SOURCE
> Task :situp-plugins:common:classes
> Task :situp-plugins:common:jar
> Task :situp-plugins:apmtracesource:compileJava
> Task :situp-plugins:apmtracesource:processResources NO-SOURCE
> Task :situp-plugins:apmtracesource:classes
> Task :situp-plugins:apmtracesource:jar
> Task :situp-plugins:elasticsearch:compileJava
> Task :situp-plugins:elasticsearch:processResources
> Task :situp-plugins:elasticsearch:classes
> Task :situp-plugins:elasticsearch:jar
> Task :situp-plugins:lmdb-processor-state:compileJava
> Task :situp-plugins:lmdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:lmdb-processor-state:classes
> Task :situp-plugins:lmdb-processor-state:jar

> Task :situp-plugins:mapdb-processor-state:compileJava
Note: /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :situp-plugins:mapdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:mapdb-processor-state:classes
> Task :situp-plugins:mapdb-processor-state:jar
> Task :situp-plugins:service-map-stateful:compileJava
> Task :situp-plugins:service-map-stateful:processResources NO-SOURCE
> Task :situp-plugins:service-map-stateful:classes
> Task :situp-plugins:service-map-stateful:jar
> Task :situp-plugins:compileJava NO-SOURCE
> Task :situp-plugins:processResources NO-SOURCE
> Task :situp-plugins:classes UP-TO-DATE
> Task :situp-plugins:jar
> Task :situp-core:compileJava
> Task :situp-core:processResources
> Task :situp-core:classes
> Task :situp-core:jar
> Task :situp-core:assemble
> Task :situp-core:compileTestJava
> Task :situp-core:processTestResources
> Task :situp-core:testClasses
> Task :situp-core:test
> Task :situp-core:check
> Task :situp-core:jacocoTestReport
> Task :situp-core:build
> Task :release:buildCore
> Task :release:endToEndTests UP-TO-DATE
> Task :release:releasePrerequisites
> Task :release:archives:linux:linuxDistZip

> Task :release:archives:linux:downloadJDK
Download https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz

> Task :release:archives:linux:linuxWithJDKDistZip
> Task :release:archives:linux:linuxZip
> Task :release:archives:macOS:macOSDistZip

> Task :release:archives:macOS:downloadJDK
Download https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz

> Task :release:archives:macOS:macOSWithJDKDistZip
> Task :release:archives:macOS:macOSZip
> Task :release:archives:buildZip

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 4m 46s


simple-ingest-transformation-utility-pipeline byadav$ ./gradlew clean :release:archives:buildTar -Prelease --console=plain
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.5
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-14.0.2.jdk/Contents/Home
  Random Testing Seed   : 39996D523E4295CD
  In FIPS 140 mode      : false
=======================================
> Task :release:clean UP-TO-DATE
> Task :research:clean UP-TO-DATE
> Task :situp-api:clean
> Task :situp-benchmarks:clean UP-TO-DATE
> Task :situp-core:clean
> Task :situp-plugins:clean
> Task :release:archives:clean UP-TO-DATE
> Task :release:docker:clean UP-TO-DATE
> Task :research:zipkin-elastic-to-otel:clean UP-TO-DATE
> Task :situp-benchmarks:lmdb-benchmarks:clean UP-TO-DATE
> Task :situp-benchmarks:mapdb-benchmarks:clean UP-TO-DATE
> Task :situp-benchmarks:service-map-stateful-benchmarks:clean UP-TO-DATE
> Task :situp-plugins:apmtracesource:clean
> Task :situp-plugins:common:clean
> Task :situp-plugins:elasticsearch:clean
> Task :situp-plugins:lmdb-processor-state:clean
> Task :situp-plugins:mapdb-processor-state:clean
> Task :situp-plugins:service-map-stateful:clean
> Task :release:archives:linux:clean
> Task :release:archives:macOS:clean
> Task :release:benchmarkTests UP-TO-DATE
> Task :situp-api:compileJava
> Task :situp-api:processResources NO-SOURCE
> Task :situp-api:classes
> Task :situp-api:jar
> Task :situp-plugins:common:compileJava
> Task :situp-plugins:common:processResources NO-SOURCE
> Task :situp-plugins:common:classes
> Task :situp-plugins:common:jar
> Task :situp-plugins:apmtracesource:compileJava
> Task :situp-plugins:apmtracesource:processResources NO-SOURCE
> Task :situp-plugins:apmtracesource:classes
> Task :situp-plugins:apmtracesource:jar
> Task :situp-plugins:elasticsearch:compileJava
> Task :situp-plugins:elasticsearch:processResources
> Task :situp-plugins:elasticsearch:classes
> Task :situp-plugins:elasticsearch:jar
> Task :situp-plugins:lmdb-processor-state:compileJava
> Task :situp-plugins:lmdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:lmdb-processor-state:classes
> Task :situp-plugins:lmdb-processor-state:jar

> Task :situp-plugins:mapdb-processor-state:compileJava
Note: /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :situp-plugins:mapdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:mapdb-processor-state:classes
> Task :situp-plugins:mapdb-processor-state:jar
> Task :situp-plugins:service-map-stateful:compileJava
> Task :situp-plugins:service-map-stateful:processResources NO-SOURCE
> Task :situp-plugins:service-map-stateful:classes
> Task :situp-plugins:service-map-stateful:jar
> Task :situp-plugins:compileJava NO-SOURCE
> Task :situp-plugins:processResources NO-SOURCE
> Task :situp-plugins:classes UP-TO-DATE
> Task :situp-plugins:jar
> Task :situp-core:compileJava
> Task :situp-core:processResources
> Task :situp-core:classes
> Task :situp-core:jar
> Task :situp-core:assemble
> Task :situp-core:compileTestJava
> Task :situp-core:processTestResources
> Task :situp-core:testClasses
> Task :situp-core:test
> Task :situp-core:check
> Task :situp-core:jacocoTestReport
> Task :situp-core:build
> Task :release:buildCore
> Task :release:endToEndTests UP-TO-DATE
> Task :release:releasePrerequisites
> Task :release:archives:linux:linuxDistTar

> Task :release:archives:linux:downloadJDK
Download https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz

> Task :release:archives:linux:linuxWithJDKDistTar
> Task :release:archives:linux:linuxTar
> Task :release:archives:macOS:macOSDistTar

> Task :release:archives:macOS:downloadJDK
Download https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz

> Task :release:archives:macOS:macOSWithJDKDistTar
> Task :release:archives:macOS:macOSTar
> Task :release:archives:buildTar

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 4m 29s
49 actionable tasks: 40 executed, 9 up-to-date

simple-ingest-transformation-utility-pipeline byadav$ ./gradlew clean :release:archives:macOS:uploadZipToS3 -Prelease --console=plain
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.5
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-14.0.2.jdk/Contents/Home
  Random Testing Seed   : 61843D239BF3A30E
  In FIPS 140 mode      : false
=======================================
> Task :release:clean UP-TO-DATE
> Task :research:clean UP-TO-DATE
> Task :situp-api:clean
> Task :situp-benchmarks:clean UP-TO-DATE
> Task :situp-core:clean
> Task :situp-plugins:clean
> Task :release:archives:clean UP-TO-DATE
> Task :release:docker:clean UP-TO-DATE
> Task :research:zipkin-elastic-to-otel:clean UP-TO-DATE
> Task :situp-benchmarks:lmdb-benchmarks:clean UP-TO-DATE
> Task :situp-benchmarks:mapdb-benchmarks:clean UP-TO-DATE
> Task :situp-benchmarks:service-map-stateful-benchmarks:clean UP-TO-DATE
> Task :situp-plugins:apmtracesource:clean
> Task :situp-plugins:common:clean
> Task :situp-plugins:elasticsearch:clean
> Task :situp-plugins:lmdb-processor-state:clean
> Task :situp-plugins:mapdb-processor-state:clean
> Task :situp-plugins:service-map-stateful:clean
> Task :release:archives:linux:clean UP-TO-DATE
> Task :release:archives:macOS:clean
> Task :release:archives:macOS:createBucket
> Task :release:benchmarkTests UP-TO-DATE
> Task :situp-api:compileJava
> Task :situp-api:processResources NO-SOURCE
> Task :situp-api:classes
> Task :situp-api:jar
> Task :situp-plugins:common:compileJava
> Task :situp-plugins:common:processResources NO-SOURCE
> Task :situp-plugins:common:classes
> Task :situp-plugins:common:jar
> Task :situp-plugins:apmtracesource:compileJava
> Task :situp-plugins:apmtracesource:processResources NO-SOURCE
> Task :situp-plugins:apmtracesource:classes
> Task :situp-plugins:apmtracesource:jar
> Task :situp-plugins:elasticsearch:compileJava
> Task :situp-plugins:elasticsearch:processResources
> Task :situp-plugins:elasticsearch:classes
> Task :situp-plugins:elasticsearch:jar
> Task :situp-plugins:lmdb-processor-state:compileJava
> Task :situp-plugins:lmdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:lmdb-processor-state:classes
> Task :situp-plugins:lmdb-processor-state:jar

> Task :situp-plugins:mapdb-processor-state:compileJava
Note: /workplace/byadav/ForkedSITUP/simple-ingest-transformation-utility-pipeline/situp-plugins/mapdb-processor-state/src/main/java/com/amazon/situp/plugins/processor/state/MapDbProcessorState.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.

> Task :situp-plugins:mapdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:mapdb-processor-state:classes
> Task :situp-plugins:mapdb-processor-state:jar
> Task :situp-plugins:service-map-stateful:compileJava
> Task :situp-plugins:service-map-stateful:processResources NO-SOURCE
> Task :situp-plugins:service-map-stateful:classes
> Task :situp-plugins:service-map-stateful:jar
> Task :situp-plugins:compileJava NO-SOURCE
> Task :situp-plugins:processResources NO-SOURCE
> Task :situp-plugins:classes UP-TO-DATE
> Task :situp-plugins:jar
> Task :situp-core:compileJava
> Task :situp-core:processResources
> Task :situp-core:classes
> Task :situp-core:jar
> Task :situp-core:assemble
> Task :situp-core:compileTestJava
> Task :situp-core:processTestResources
> Task :situp-core:testClasses
> Task :situp-core:test
> Task :situp-core:check
> Task :situp-core:jacocoTestReport
> Task :situp-core:build
> Task :release:buildCore
> Task :release:endToEndTests UP-TO-DATE
> Task :release:releasePrerequisites
> Task :release:archives:macOS:macOSDistZip

> Task :release:archives:macOS:uploadZipToS3
JAXB is unavailable. Will fallback to SDK implementation which may be less performant

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2m 40s
46 actionable tasks: 36 executed, 10 up-to-date

simple-ingest-transformation-utility-pipeline byadav$ ./gradlew  :release:archives:uploadArchives -Prelease --console=plain
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.5
  OS Info               : Mac OS X 10.14.6 (x86_64)
  JDK Version           : 14 (Oracle JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/jdk-14.0.2.jdk/Contents/Home
  Random Testing Seed   : 2A328B4117B126AE
  In FIPS 140 mode      : false
=======================================
> Task :release:archives:linux:createBucket
> Task :release:benchmarkTests UP-TO-DATE
> Task :situp-api:compileJava UP-TO-DATE
> Task :situp-api:processResources NO-SOURCE
> Task :situp-api:classes UP-TO-DATE
> Task :situp-api:jar UP-TO-DATE
> Task :situp-plugins:common:compileJava UP-TO-DATE
> Task :situp-plugins:common:processResources NO-SOURCE
> Task :situp-plugins:common:classes UP-TO-DATE
> Task :situp-plugins:common:jar UP-TO-DATE
> Task :situp-plugins:apmtracesource:compileJava UP-TO-DATE
> Task :situp-plugins:apmtracesource:processResources NO-SOURCE
> Task :situp-plugins:apmtracesource:classes UP-TO-DATE
> Task :situp-plugins:apmtracesource:jar UP-TO-DATE
> Task :situp-plugins:elasticsearch:compileJava UP-TO-DATE
> Task :situp-plugins:elasticsearch:processResources UP-TO-DATE
> Task :situp-plugins:elasticsearch:classes UP-TO-DATE
> Task :situp-plugins:elasticsearch:jar UP-TO-DATE
> Task :situp-plugins:lmdb-processor-state:compileJava UP-TO-DATE
> Task :situp-plugins:lmdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:lmdb-processor-state:classes UP-TO-DATE
> Task :situp-plugins:lmdb-processor-state:jar UP-TO-DATE
> Task :situp-plugins:mapdb-processor-state:compileJava UP-TO-DATE
> Task :situp-plugins:mapdb-processor-state:processResources NO-SOURCE
> Task :situp-plugins:mapdb-processor-state:classes UP-TO-DATE
> Task :situp-plugins:mapdb-processor-state:jar UP-TO-DATE
> Task :situp-plugins:service-map-stateful:compileJava UP-TO-DATE
> Task :situp-plugins:service-map-stateful:processResources NO-SOURCE
> Task :situp-plugins:service-map-stateful:classes UP-TO-DATE
> Task :situp-plugins:service-map-stateful:jar UP-TO-DATE
> Task :situp-plugins:compileJava NO-SOURCE
> Task :situp-plugins:processResources NO-SOURCE
> Task :situp-plugins:classes UP-TO-DATE
> Task :situp-plugins:jar UP-TO-DATE
> Task :situp-core:compileJava UP-TO-DATE
> Task :situp-core:processResources UP-TO-DATE
> Task :situp-core:classes UP-TO-DATE
> Task :situp-core:jar UP-TO-DATE
> Task :situp-core:assemble UP-TO-DATE
> Task :situp-core:compileTestJava UP-TO-DATE
> Task :situp-core:processTestResources UP-TO-DATE
> Task :situp-core:testClasses UP-TO-DATE
> Task :situp-core:test UP-TO-DATE
> Task :situp-core:check UP-TO-DATE
> Task :situp-core:jacocoTestReport UP-TO-DATE
> Task :situp-core:build UP-TO-DATE
> Task :release:buildCore UP-TO-DATE
> Task :release:endToEndTests UP-TO-DATE
> Task :release:releasePrerequisites UP-TO-DATE
> Task :release:archives:linux:linuxDistTar UP-TO-DATE
> Task :release:archives:linux:uploadTarToS3
> Task :release:archives:linux:downloadJDK
> Task :release:archives:linux:linuxWithJDKDistTar UP-TO-DATE
> Task :release:archives:linux:uploadTarWithJDKToS3
> Task :release:archives:linux:linuxDistZip
> Task :release:archives:linux:uploadZipToS3
> Task :release:archives:linux:linuxWithJDKDistZip
> Task :release:archives:linux:uploadZipWithJDKToS3
> Task :release:archives:linux:uploadToS3
> Task :release:archives:macOS:createBucket
> Task :release:archives:macOS:macOSDistTar UP-TO-DATE
> Task :release:archives:macOS:uploadTarToS3
> Task :release:archives:macOS:downloadJDK
> Task :release:archives:macOS:macOSWithJDKDistTar UP-TO-DATE
> Task :release:archives:macOS:uploadTarWithJDKToS3
> Task :release:archives:macOS:macOSDistZip
> Task :release:archives:macOS:uploadZipToS3
> Task :release:archives:macOS:macOSWithJDKDistZip
> Task :release:archives:macOS:uploadZipWithJDKToS3
> Task :release:archives:macOS:uploadToS3
> Task :release:archives:uploadArchives

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 7m 45s
43 actionable tasks: 16 executed, 27 up-to-date
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
