### PR TITLE
Added config flag to enable gRPC server reflection.

### DIFF
--- a/situp-plugins/apmtracesource/README.md
+++ b/situp-plugins/apmtracesource/README.md
@@ -11,7 +11,8 @@ source:
 
 * port => Default is ```21890```. 
 * request_timeout => Default is ```10_000``` millis.
-* health_check => This will add health check at <your_host>:port/health_check.
+* health_check_service => This will enable a gRPC health check service under ```grpc.health.v1 / Health / Check```. Default is ```false```.
+* proto_reflection_service => This will enable a reflection service for Protobuf services (see [ProtoReflectionService](https://grpc.github.io/grpc-java/javadoc/io/grpc/protobuf/services/ProtoReflectionService.html) and [gRPC reflection](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is ```false```.
 * ssl => Default is ```false```.
 * sslKeyCertChainFile => Should be provided if ```ssl``` is set to ```true```
 * sslKeyFile => Should be provided if ```ssl``` is set to ```true```

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSource.java
@@ -11,6 +11,7 @@ import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.armeria.server.grpc.GrpcServiceBuilder;
+import io.grpc.protobuf.services.ProtoReflectionService;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,8 +42,12 @@ public class OTelTraceSource implements Source<Record<ExportTraceServiceRequest>
                     .addService(new HealthGrpcService())
                     .useClientTimeoutHeader(false);
 
-            if (oTelTraceSourceConfig.isHealthCheck()) {
+            if (oTelTraceSourceConfig.hasHealthCheck()) {
                 grpcServiceBuilder.addService(new HealthGrpcService());
+            }
+
+            if (oTelTraceSourceConfig.hasProtoReflectionService()) {
+                grpcServiceBuilder.addService(ProtoReflectionService.newInstance());
             }
 
             final ServerBuilder sb = Server.builder();

--- a/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSourceConfig.java
+++ b/situp-plugins/apmtracesource/src/main/java/com/amazon/situp/plugins/source/oteltracesource/OTelTraceSourceConfig.java
@@ -6,7 +6,8 @@ public class OTelTraceSourceConfig {
     private static final String REQUEST_TIMEOUT = "request_timeout";
     private static final String PORT = "port";
     private static final String SSL = "ssl";
-    private static final String HEALTH_CHECK = "health_check";
+    private static final String HEALTH_CHECK_SERVICE = "health_check_service";
+    private static final String PROTO_REFLECTION_SERVICE = "proto_reflection_service";
     private static final String SSL_KEY_CERT_FILE = "sslKeyCertChainFile";
     private static final String SSL_KEY_FILE = "sslKeyFile";
     private static final int DEFAULT_REQUEST_TIMEOUT = 10_000;
@@ -15,15 +16,23 @@ public class OTelTraceSourceConfig {
     private final int requestTimeoutInMillis;
     private final int port;
     private final boolean healthCheck;
+    private final boolean protoReflectionService;
     private final boolean ssl;
     private final String sslKeyCertChainFile;
     private final String sslKeyFile;
 
 
-    private OTelTraceSourceConfig(int requestTimeoutInMillis, int port, boolean health_check, boolean isSSL, String sslKeyCertChainFile, String sslKeyFile) {
+    private OTelTraceSourceConfig(final int requestTimeoutInMillis,
+                                  final int port,
+                                  final boolean healthCheck,
+                                  final boolean protoReflectionService,
+                                  final boolean isSSL,
+                                  final String sslKeyCertChainFile,
+                                  final String sslKeyFile) {
         this.requestTimeoutInMillis = requestTimeoutInMillis;
         this.port = port;
-        this.healthCheck = health_check;
+        this.healthCheck = healthCheck;
+        this.protoReflectionService = protoReflectionService;
         this.ssl = isSSL;
         this.sslKeyCertChainFile = sslKeyCertChainFile;
         this.sslKeyFile = sslKeyFile;
@@ -38,7 +47,8 @@ public class OTelTraceSourceConfig {
     public static OTelTraceSourceConfig buildConfig(final PluginSetting pluginSetting) {
         return new OTelTraceSourceConfig(pluginSetting.getIntegerOrDefault(REQUEST_TIMEOUT, DEFAULT_REQUEST_TIMEOUT),
                 pluginSetting.getIntegerOrDefault(PORT, DEFAULT_PORT),
-                pluginSetting.getBooleanOrDefault(HEALTH_CHECK, false),
+                pluginSetting.getBooleanOrDefault(HEALTH_CHECK_SERVICE, false),
+                pluginSetting.getBooleanOrDefault(PROTO_REFLECTION_SERVICE, false),
                 pluginSetting.getBooleanOrDefault(SSL, DEFAULT_SSL),
                 pluginSetting.getStringOrDefault(SSL_KEY_CERT_FILE, null),
                 pluginSetting.getStringOrDefault(SSL_KEY_FILE, null));
@@ -52,8 +62,12 @@ public class OTelTraceSourceConfig {
         return port;
     }
 
-    public boolean isHealthCheck() {
+    public boolean hasHealthCheck() {
         return healthCheck;
+    }
+
+    public boolean hasProtoReflectionService() {
+        return protoReflectionService;
     }
 
     public boolean isSsl() {


### PR DESCRIPTION
*Issue #, if available:* #160 

*Description of changes:*
Adding a flag for server reflection, to allow for debugging/testing with gRPC tools such as [gprcurl](https://github.com/fullstorydev/grpcurl) and [evans](https://github.com/ktr0731/evans).

With both `health_check_service: true` and `proto_reflection_service: true`:

```
[/home/wrijeff/testing] ./grpcurl -plaintext 127.0.0.1:21890 grpc.health.v1.Health/Check
{
  "status": "SERVING"
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
